### PR TITLE
Keep one XuanjiNovo modification notation, not two

### DIFF
--- a/src/instanovo_fm/eval/_predict_de_novo_common.py
+++ b/src/instanovo_fm/eval/_predict_de_novo_common.py
@@ -46,21 +46,12 @@ CASANOVO_TO_UNIMOD: dict[str, str] = {
     "[+25.980265]": "[UNIMOD:5][UNIMOD:385]",
 }
 
-# The *vendored* XuanjiNovo decoder detokenises to unbracketed mass-offset notation (e.g. "C+57.021",
-# "M+15.995", "+42.011") — used by the in-repo greedy baseline (predict_xuanjinovo_de_novo).
-XUANJINOVO_TO_UNIMOD: dict[str, str] = {
-    "C+57.021": "C[UNIMOD:4]",
-    "M+15.995": "M[UNIMOD:35]",
-    "N+0.984": "N[UNIMOD:7]",
-    "Q+0.984": "Q[UNIMOD:7]",
-    "+42.011": "[UNIMOD:1]",  # acetylation (N-term)
-    "+43.006": "[UNIMOD:5]",  # carbamylation (N-term)
-    "-17.027": "[UNIMOD:385]",  # loss of ammonia (N-term)
-}
-
-# The *upstream* XuanjiNovo model's denovo.tsv writes the same offsets in BRACKETED notation
-# (e.g. "C[+57.021]", "M[+15.995]", "[+42.011]") — used by the faithful AIchor pipeline
-# (score_xuanjinovo). Same masses as XUANJINOVO_TO_UNIMOD, different surface syntax.
+# XuanjiNovo writes modifications as bracketed mass offsets (e.g. "C[+57.021]",
+# "M[+15.995]", "[+42.011]"), both in the upstream model's denovo.tsv that
+# score_xuanjinovo reads and in the residue vocabulary convert_parquet_to_mgf
+# filters against. There used to be a second table for the same masses in
+# unbracketed notation, for an in-repo greedy baseline that no longer exists;
+# both notations produced an identical canonical vocabulary, so one is enough.
 XUANJINOVO_BRACKETED_TO_UNIMOD: dict[str, str] = {
     "C[+57.021]": "C[UNIMOD:4]",
     "M[+15.995]": "M[UNIMOD:35]",
@@ -74,7 +65,6 @@ XUANJINOVO_BRACKETED_TO_UNIMOD: dict[str, str] = {
 
 MODEL_SCORING: dict[str, dict[str, Any]] = {
     "casanovo": {"residue_remapping": CASANOVO_TO_UNIMOD},
-    "xuanjinovo": {"residue_remapping": XUANJINOVO_TO_UNIMOD},  # TODO is this used?
     "xuanjinovo_upstream": {"residue_remapping": XUANJINOVO_BRACKETED_TO_UNIMOD},
 }
 

--- a/src/instanovo_fm/eval/convert_parquet_to_mgf.py
+++ b/src/instanovo_fm/eval/convert_parquet_to_mgf.py
@@ -12,7 +12,7 @@ import pandas as pd
 from instanovo.__init__ import console
 from instanovo_fm.eval._extract_embeddings_common import load_spectrum_dataframe
 from instanovo_fm.eval._predict_de_novo_common import (
-    XUANJINOVO_TO_UNIMOD,
+    XUANJINOVO_BRACKETED_TO_UNIMOD,
     _resolve_group,
     build_model_vocab,
     filter_unpredictable_rows,
@@ -44,13 +44,13 @@ XUANJINOVO_RESIDUES: List[str] = [
     "R",
     "Y",
     "W",
-    "C+57.021",  # cysteine, fixed carbamidomethyl
-    "M+15.995",  # oxidised methionine (variable)
-    "N+0.984",
-    "Q+0.984",  # deamidation
-    "+42.011",  # acetylation (N-term)
-    "+43.006",  # carbamylation (N-term)
-    "-17.027",  # loss of ammonia (N-term)
+    "C[+57.021]",  # cysteine, fixed carbamidomethyl
+    "M[+15.995]",  # oxidised methionine (variable)
+    "N[+0.984]",
+    "Q[+0.984]",  # deamidation
+    "[+42.011]",  # acetylation (N-term)
+    "[+43.006]",  # carbamylation (N-term)
+    "[-17.027]",  # loss of ammonia (N-term)
 ]
 
 
@@ -119,7 +119,7 @@ def _filter_dataset(
     has_targets = "sequence" in df.columns
     if not has_targets:
         logger.warning("No 'sequence' column found — sidecar targets will be empty (de novo mode).")
-    model_vocab = build_model_vocab(XUANJINOVO_RESIDUES, XUANJINOVO_TO_UNIMOD)
+    model_vocab = build_model_vocab(XUANJINOVO_RESIDUES, XUANJINOVO_BRACKETED_TO_UNIMOD)
     effective_max_charge = reconcile_max_charge(max_charge, MAX_CHARGE, "XuanjiNovo")
     df = filter_unpredictable_rows(df, max_charge=effective_max_charge, model_vocab=model_vocab, model_name="XuanjiNovo").reset_index(drop=True)
     if len(df) == 0:

--- a/src/instanovo_fm/eval/run_baseline_de_novo.py
+++ b/src/instanovo_fm/eval/run_baseline_de_novo.py
@@ -57,11 +57,10 @@ def _load_model_and_predictor(model: str) -> tuple[Any, Any]:
         from instanovo_fm.eval.predict_casanovo_de_novo import predict_dataframe as casanovo_predict
 
         return load_casanovo_model, casanovo_predict
-    if model == "xuanjinovo":
-        from instanovo_fm.eval.predict_xuanjinovo_de_novo import load_xuanjinovo_model
-        from instanovo_fm.eval.predict_xuanjinovo_de_novo import predict_dataframe as xuanjinovo_predict
-
-        return load_xuanjinovo_model, xuanjinovo_predict
+    # XuanjiNovo has no greedy in-repo predictor: it goes through the upstream
+    # model, via run_xuanjinovo.py and score_xuanjinovo.py. This used to import
+    # predict_xuanjinovo_de_novo, which does not exist, so asking for it raised
+    # ModuleNotFoundError instead of the error below.
     raise NotImplementedError(f"No de novo predictor wired up for model={model!r}.")
 
 


### PR DESCRIPTION
Settles the `XUANJINOVO_TO_UNIMOD` question the port left open, and it turned out to be less alarming than it looked.

## What the question was

`_predict_de_novo_common.py` carried **two tables mapping the same seven modification masses** to UNIMOD — one keyed on unbracketed offsets (`"C+57.021"`), one on bracketed (`"C[+57.021]"`). The internal branch had deleted the unbracketed one, which `convert_parquet_to_mgf.py` imports, so a naive reconciliation would break the import.

## What it actually was

Taken alone, yes. But the internal branch moved the **pair** together: its `XUANJINOVO_RESIDUES` is bracketed too, so its `build_model_vocab` call is consistent. Both repositories were internally consistent and merely differed in notation — there was no semantic conflict to arbitrate, and no decision needed from whoever owns the baseline.

| | residues | table | consistent |
|---|---|---|---|
| this repo (before) | `C+57.021` | `XUANJINOVO_TO_UNIMOD` | ✅ |
| internal | `C[+57.021]` | `XUANJINOVO_BRACKETED_TO_UNIMOD` | ✅ |

## What this does

Adopts the internal form: one table for one set of masses, in the notation XuanjiNovo actually emits — both in the upstream `denovo.tsv` that `score_xuanjinovo` parses and now in the vocabulary `convert_parquet_to_mgf` filters against, so there is no translation step between them.

**Behaviour is unchanged, and proven rather than asserted:** `build_model_vocab` returns the same 25-residue canonical vocabulary under either notation. That vocabulary is load bearing — `filter_unpredictable_rows` uses it to drop target peptides XuanjiNovo structurally cannot emit, so the baseline is not charged for them — which is why it was worth proving.

## Two dead things went with it

- **`MODEL_SCORING["xuanjinovo"]`**, which carried the unbracketed table and a `# TODO is this used?`, is never read — `score_xuanjinovo` passes `XUANJINOVO_BRACKETED_TO_UNIMOD` directly. The answer to the TODO was no.
- **`run_baseline_de_novo.py`'s `xuanjinovo` branch** imported `instanovo_fm.eval.predict_xuanjinovo_de_novo`, which does not exist in this repository and never has — so asking for that predictor raised `ModuleNotFoundError` rather than the `NotImplementedError` the function documents. The in-repo greedy baseline it referred to is gone; XuanjiNovo de novo runs through the upstream model via `run_xuanjinovo.py` / `score_xuanjinovo.py`, which is where the manuscript's numbers came from. `MODELS` still registers `xuanjinovo`, since that entry resolves its checkpoint for the embedding path.

## Side effect worth having

This closes drift against the internal branch for one of the **nine baseline files with no common ancestor**: `convert_parquet_to_mgf.py` is now identical to it (18 → 0 lines). `_predict_de_novo_common.py` drops from 98 to 90; the remainder is the legitimate `parents[1]` path adaptation and fuller docstrings.

Full write-up of the nine: `~/Documents/markdown/instanovo-fm-baseline-file-lineage.md` — now with its central question answered.

## Verification

- `build_model_vocab` vocabulary identical before and after (25 residues)
- `_load_model_and_predictor("xuanjinovo")` raises `NotImplementedError`; `casanovo` still resolves
- pre-commit `run --all-files` passes
- pytest **879 passed / 12 skipped / 8 xfailed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)