### PR TITLE
Record the baseline licences in docker/README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -14,6 +14,43 @@ Both write embeddings in the HDF5 layout `instanovo_fm.eval.embedding_io` reads,
 so the linear-probe, retrieval and UMAP tasks run on identical downstream code
 regardless of which encoder produced the embeddings.
 
+## Licences
+
+Neither baseline is vendored here. Each image builds its dependency from
+upstream at a pinned version, so what follows is what those upstreams are
+licensed under, not a licence this repository grants. The adapters under
+`src/instanovo_fm/eval/` are ours and are Apache-2.0 like the rest of the
+repository.
+
+| what the image pulls in | version pinned | licence |
+|---|---|---|
+| [Casanovo](https://github.com/Noble-Lab/casanovo) | `casanovo==5.1.2` from PyPI | Apache-2.0 |
+| Casanovo checkpoint `casanovo_v5_0_0.ckpt` | the `v5.0.0` release asset | see below |
+| [MassNet-DDA](https://github.com/guomics-lab/MassNet-DDA) (XuanjiNovo) | commit `84105ec` | Apache-2.0, © 2024 PHOENIX center |
+| [`ctcdecode`](https://github.com/parlance/ctcdecode) | the copy in that MassNet-DDA commit | MIT |
+| [`imputer-pytorch`](https://github.com/rosinality/imputer-pytorch) | the copy in that MassNet-DDA commit | MIT |
+| [CuPy](https://github.com/cupy/cupy) | `cupy-cuda12x==13.6.0` | MIT |
+
+GitHub reports MassNet-DDA's licence as "Other" because its `LICENSE` is the
+short-form Apache notice rather than the full text. It is Apache-2.0: read the
+file at the pinned commit if you need to confirm that for yourself.
+
+Two things the table cannot tell you.
+
+**The model weights are not the code.** Both images fetch a trained checkpoint,
+and neither upstream states terms for its weights separately from its source. The
+Casanovo checkpoint comes from a GitHub release asset; XuanjiNovo's is fetched
+separately at run time rather than baked in. If you intend to redistribute either
+checkpoint, or anything derived from one, that is worth asking the authors about
+rather than inferring from the repository licence.
+
+**`Dockerfile.xuanjinovo` builds on `pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime`,**
+which carries CUDA and cuDNN under NVIDIA's own terms, not an open-source licence.
+The same applies to a default install of this project, and
+[`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md) sets out what that means —
+it matters most if you push either image to a registry, because then you are
+redistributing NVIDIA's binaries under NVIDIA's terms.
+
 Every third-party baseline import in `src/instanovo_fm/eval/` is inside a
 function, never at module scope. That is what lets the adapters sit on `main`:
 importing `instanovo_fm.eval` does not require Casanovo or the MassNet stack.


### PR DESCRIPTION
`docker/README.md` explained why Casanovo and XuanjiNovo each need their own interpreter, but never said what either is licensed under. Anyone pushing one of these images to a registry is redistributing that code, so it belongs next to the Dockerfile that pulls it.

## What they are

Checked upstream rather than assumed:

| what the image pulls in | version pinned | licence |
|---|---|---|
| [Casanovo](https://github.com/Noble-Lab/casanovo) | `casanovo==5.1.2` from PyPI | Apache-2.0 |
| [MassNet-DDA](https://github.com/guomics-lab/MassNet-DDA) (XuanjiNovo) | commit `84105ec` | Apache-2.0, © 2024 PHOENIX center |
| [`ctcdecode`](https://github.com/parlance/ctcdecode) | the copy in that commit | MIT |
| [`imputer-pytorch`](https://github.com/rosinality/imputer-pytorch) | the copy in that commit | MIT |
| [CuPy](https://github.com/cupy/cupy) | `cupy-cuda12x==13.6.0` | MIT |

**MassNet-DDA needed checking.** GitHub reports its licence as "Other" / `NOASSERTION`, which reads like an unlicensed repository. It isn't — the `LICENSE` file at the pinned commit is the short-form Apache notice, which GitHub's classifier doesn't recognise. Reading the file settles it, and the README says so, so the next person doesn't have to repeat the doubt.

Every version in the table is the one the Dockerfiles actually pin — verified against `ARG CASANOVO_VERSION`, `ARG MASSNET_COMMIT`, the `cupy-cuda12x` pin and the base-image tag, not recalled.

## Two things a licence table can't carry

**Model weights are not code.** Both images fetch a trained checkpoint, and *neither upstream states terms for its weights separately from its source*. Casanovo's comes from a `v5.0.0` release asset; XuanjiNovo's is fetched separately at run time rather than baked in. Redistributing either checkpoint — or something derived from one — is a question for the authors, not something to infer from a repository licence. Flagged rather than answered, because I can't answer it.

**`Dockerfile.xuanjinovo` builds on `pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime`**, which carries CUDA and cuDNN under NVIDIA's terms rather than an open-source licence. Same exposure a default install of this project already has, so it points at [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md) instead of restating it. It matters most on `docker push`.

Documentation only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)