### PR TITLE
Bump the PyPI publish action past the metadata 2.5 rejection

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -63,9 +63,13 @@ jobs:
       - name: List what would be uploaded
         run: ls -lh dist/
 
+      # v1.14.2 or newer: the Twine bundled inside older releases predates
+      # Metadata-Version 2.5, which hatchling emits, and rejects the wheel with
+      # `InvalidDistribution: '2.5' is not a valid metadata version` before it
+      # uploads anything.
       - name: Publish to PyPI
         if: github.event_name == 'release' || inputs.dry_run == false
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.2
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Publishing `v0.1.0` failed. The action's own bundled Twine rejected the wheel **before uploading anything**:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

hatchling emits `Metadata-Version: 2.5`; the Twine inside `gh-action-pypi-publish@v1.13.0` predates it. [v1.14.2](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.2) updates that bundled Twine to v7, which reads it.

**Nothing reached PyPI** — `pypi.org/pypi/instanovo-fm/json` still returns 404, so `0.1.0` is not burnt and the release can be published again from the same tag.

## Why the workflow's own check didn't catch it

The `uvx twine check dist/*` step passed on this exact wheel. `uvx` resolves a *current* Twine; the action carries its own, older one. So the step verifies the metadata is valid but cannot vouch for what the uploader will accept — which is why the action version is the thing that had to move, not the check.

## Re-publishing after this merges

The release is already published, so `release: published` will not fire again. The workflow's `workflow_dispatch` covers it:

```bash
gh workflow run python-publish.yml --repo instadeepai/InstaNovo-FM -f dry_run=false
```

The tag-vs-version guard is skipped on a dispatch by design — `GITHUB_REF_NAME` is the branch there, not the tag — and `0.1.0` was already checked against `v0.1.0` when the release ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)