### PR TITLE
Point the docs at the published package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **A self-supervised foundation model for proteomics tandem mass spectra**
 
-<!-- Badges: update the PyPI and Colab URLs once those are live -->
-[![PyPI version](https://img.shields.io/badge/pypi-coming--soon-lightgrey.svg)](#)
+<!-- Badges: update the Colab URL once the notebook is live -->
+[![PyPI version](https://img.shields.io/pypi/v/instanovo-fm.svg)](https://pypi.org/project/instanovo-fm/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
 [![DOI](https://img.shields.io/badge/DOI-10.64898%2F2026.09.03.747733-blue.svg)](https://doi.org/10.64898/2026.09.03.747733)
 [![Open In Colab](https://img.shields.io/badge/Colab-coming--soon-lightgrey.svg)](#)
@@ -65,16 +65,19 @@ Then open a notebook and select the **InstaNovo-FM (figures)** kernel.
 
 ## Installation
 
-We support Python 3.10–3.13 and use [uv](https://docs.astral.sh/uv/) for dependency management.
+We support Python 3.10–3.13.
 
 ```bash
-git clone https://github.com/instadeepai/InstaNovo-FM.git
-cd InstaNovo-FM
-
-uv sync                    # model, dataset pipeline and evaluation harness
-uv sync --group figures    # when you want to reproduce the figures
-uv sync --extra interpret  # for UMAP visualization
+pip install instanovo-fm                # model, dataset pipeline and evaluation harness
+pip install "instanovo-fm[interpret]"   # adds UMAP visualization
+pip install "instanovo-fm[clustering]"  # adds the EvoC clustering eval task
 ```
+
+Two things live in the repository rather than the package: the figure notebooks
+(see [Reproducing the figures](#reproducing-the-figures)) and the `figures` and `dev`
+dependency groups, which are [PEP 735](https://peps.python.org/pep-0735/) groups rather
+than extras and so resolve only from a checkout, through
+[uv](https://docs.astral.sh/uv/).
 
 ## Quick start
 
@@ -317,10 +320,13 @@ If you use InstaNovo-FM in your research, please cite:
 
 ```bibtex
 @article{instanovofm,
-  title   = {Learning from tandem mass spectra at scale with a self-supervised foundation model for proteomics},
-  author  = {Nieuwoudt, Mechiel and Reverenna, Marco and Patel, Divanisha and Catzel, Rachel and Houngue, Isaac H.J.
-             and Daniel, Jemma and Eloff, Kevin and Santos, Alberto and Lopez Carranza, Nicolas and Jenkins, Timothy P.
-             and Van Goey, Jeroen and Kalogeropoulos, Konstantinos},
+  title   = {Learning from tandem mass spectra at scale with a self-supervised foundation
+             model for proteomics},
+  author  = {Nieuwoudt, Mechiel and Reverenna, Marco and Patel, Divanisha
+             and Catzel, Rachel and Houngue, Isaac H.J. and Daniel, Jemma
+             and Eloff, Kevin and Santos, Alberto and Lopez Carranza, Nicolas
+             and Jenkins, Timothy P. and Van Goey, Jeroen
+             and Kalogeropoulos, Konstantinos},
   year    = {2026},
   journal = {bioRxiv},
   doi     = {10.64898/2026.09.03.747733},
@@ -358,7 +364,7 @@ Developed by:
 - [Novo Nordisk Foundation Biotechnology Research Institute for the Green Transition](https://www.dtu.dk/), Technical University of Denmark
 - [Department of Biotechnology and Biomedicine](https://orbit.dtu.dk/en/organisations/department-of-biotechnology-and-biomedicine), Technical University of Denmark
 - [Center for Translational Protein Design](https://www.dtu.dk/)
-- Delft University of Technology & the Kavli Institute of Nanoscience
+- [Delft University of Technology](https://www.tudelft.nl/en/) & the [Kavli Institute of Nanoscience](https://kavli.tudelft.nl/)
 
 Built on public proteomics data from the [PRIDE](https://www.ebi.ac.uk/pride/) repository and the
 broader open-proteomics community.

--- a/README.md
+++ b/README.md
@@ -73,12 +73,6 @@ pip install "instanovo-fm[interpret]"   # adds UMAP visualization
 pip install "instanovo-fm[clustering]"  # adds the EvoC clustering eval task
 ```
 
-Two things live in the repository rather than the package: the figure notebooks
-(see [Reproducing the figures](#reproducing-the-figures)) and the `figures` and `dev`
-dependency groups, which are [PEP 735](https://peps.python.org/pep-0735/) groups rather
-than extras and so resolve only from a checkout, through
-[uv](https://docs.astral.sh/uv/).
-
 ## Quick start
 
 Everything is driven by module entry points and Hydra configs from

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -7,21 +7,27 @@ This tutorial trains a small model on your own data and then reads embeddings ou
 If you want to know what the model is before running it, read
 [The InstaNovo Foundation Model](foundation_model.md) first.
 
-> **There is no pretrained checkpoint to download yet**
+> **This tutorial trains its own small model**
 >
-> The weights behind the paper are not published, so this tutorial trains a small model from
-> scratch. That is enough to see the training signal and inspect the embedding space, but it is
-> not the published model — see
-> [Reproduce the Foundation Model results](reproducing_paper_results.md) for that configuration.
+> Training from scratch is what shows you the training signal, so that is what the steps below
+> do — the result is not the published model. If you only want embeddings, load the published
+> weights instead and skip to the embedding section:
+>
+> ```python
+> from instanovo_fm.model.encoder import FoundationModel
+>
+> model, config = FoundationModel.from_pretrained("instanovo-fm-v0.1.0")
+> ```
+>
+> To retrain the published model yourself, see
+> [Reproduce the Foundation Model results](reproducing_paper_results.md).
 
 ## Installation
 
-Install from source, following the [Installation section of the README](../README.md#installation):
+Install the package, as in the [Installation section of the README](../README.md#installation):
 
 ```bash
-git clone https://github.com/instadeepai/InstaNovo-FM.git
-cd InstaNovo-FM
-uv sync
+pip install instanovo-fm
 ```
 
 Then check the CLI is present:
@@ -30,8 +36,8 @@ Then check the CLI is present:
 instanovo-fm --help
 ```
 
-You should see two commands, `train` and `evaluate`. If you would rather not install the console
-script, `python -m instanovo_fm.cli` works identically.
+You should see three commands: `train`, `evaluate` and `denovo`. If you would rather not
+install the console script, `python -m instanovo_fm.cli` works identically.
 
 > **A GPU matters more here than for inference**
 >

--- a/docs/reproducing_paper_results.md
+++ b/docs/reproducing_paper_results.md
@@ -26,10 +26,11 @@ instanovo-fm train \
 
 A bare `foundation_base` run does not reproduce the paper.
 
-> **The trained weights are not published yet**
+> **You can skip the training run**
 >
-> There is no checkpoint to download, so reproducing the numbers below means training the
-> model with the command above first. The weights will be released with the codebase.
+> The published weights are a release asset, so reproducing the numbers below does not require
+> training the model first. `FoundationModel.from_pretrained("instanovo-fm-v0.1.0")` fetches
+> them, and `FoundationModel.describe_pretrained()` lists the ablation checkpoints alongside it.
 
 ## Reproducing the probe results
 


### PR DESCRIPTION
The v0.1.0 release is out and `instanovo-fm` is on PyPI, so the docs should stop
describing an unreleased project.

- **Badge** — `pypi-coming-soon` becomes `img.shields.io/pypi/v/instanovo-fm`,
  linked to the project page. It reports `v0.1.0` today and tracks later releases
  without another edit.
- **Installation** — `pip install` replaces the `git clone` in both the README and
  `docs/getting_started.md`. `interpret` and `clustering` are listed as extras and
  were dry-run resolved against the live package; `s3` is not, because `boto3` and
  `s3fs` already arrive transitively, so the extra installs nothing.
- **What pip cannot give you** — `figures` and `dev` are PEP 735 dependency groups
  rather than extras, and the figure notebooks are not in the wheel, so both still
  need a checkout. Stated under the install block rather than left to be discovered.
- **Stale callouts** — two notices still said the weights were unpublished. They now
  point at `from_pretrained("instanovo-fm-v0.1.0")`. The `--help` output has also had
  a third command, `denovo`, since #29.
- **Affiliations** — TU Delft and the Kavli Institute of Nanoscience are linked like
  the other entries. Note that the obvious `tudelft.nl` sub-path for Kavli 404s;
  `kavli.tudelft.nl` is the live site.
- **BibTeX** — the title is split after "foundation" as requested, but the author
  lines were 116 and 119 characters against the title's 89, so they were the real
  cause of the sideways scroll. Both are rewrapped to 89.
