### PR TITLE
Fix: data preprocessing pipeline review follow-ups

### DIFF
--- a/scripts/preprocessing/README.md
+++ b/scripts/preprocessing/README.md
@@ -10,7 +10,7 @@ Run them from the repository root as `uv run python -m scripts.preprocessing.<sc
 
 1. Detect duplicates, both same-folder and multi-folder. Multi-folder hits need a person to decide which copy to keep; the scripts cannot choose the true file for you.
 2. Delete same-folder duplicates, then delete the reviewed multi-folder duplicates.
-3. Find and remove empty or undersized files.
+3. Find and remove empty files.
 4. Convert IPC to Parquet, then check that every IPC file has a converted counterpart.
 5. Clean columns: replace `"Unknown"` with null in `collision_energy` and `frag_type`, infer missing isolation targets, re-label EncyclopeDIA modifications as UNIMOD, and add the `acquisition` column (DIA/DDA) from search metadata.
 
@@ -42,7 +42,6 @@ uv run python -m scripts.preprocessing.delete_same_folder_duplicates --input-fil
 
 ```bash
 uv run python -m scripts.preprocessing.find_empty_files --input-dir ./data --output-file empty_files.txt
-uv run python -m scripts.preprocessing.find_empty_files --input-dir ./data --min-size 1024 --output-file small_files.txt
 uv run python -m scripts.preprocessing.find_empty_files --input-dir ./acfm --input-dir ./lcfm --output-file empty_files.txt
 ```
 

--- a/scripts/preprocessing/README.md
+++ b/scripts/preprocessing/README.md
@@ -209,6 +209,9 @@ Default column mapping, which can be customised:
 {
   "rt": "retention_time",
   "mz": "mz_array",
-  "intensity": "intensity_array"
+  "intensity": "intensity_array",
+  "peptide": "unmodified_peptide"
 }
 ```
+
+`--column-mapping` JSON is merged onto these defaults (overrides win; other defaults remain).

--- a/scripts/preprocessing/add_acquisition_column.py
+++ b/scripts/preprocessing/add_acquisition_column.py
@@ -23,7 +23,11 @@ from tqdm import tqdm
 
 from scripts.logging_setup import configure_script_logging
 from scripts.paths import DEFAULT_SEARCH_DATA
-from scripts.preprocessing.parquet_io import atomic_write_parquet, search_data_lookup_key
+from scripts.preprocessing.parquet_io import (
+    atomic_write_parquet,
+    get_storage_options,
+    search_data_lookup_key,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -241,10 +245,11 @@ def _process_data_file_with_acquisition(
     acquisition: str,
     dry_run: bool,
     verbose: bool,
+    storage_options: Optional[dict] = None,
 ) -> Literal["updated", "already_has_column", "error"]:
     """Keep per-file failures from aborting acquisition enrichment for the dataset."""
     try:
-        df = pl.read_parquet(file_path)
+        df = pl.read_parquet(file_path, storage_options=storage_options)
 
         if "acquisition" in df.columns:
             existing_values = (
@@ -274,7 +279,7 @@ def _process_data_file_with_acquisition(
                     f"[DRY RUN] Would set acquisition={acquisition} on {project}/{filename}"
                 )
         else:
-            atomic_write_parquet(df, file_path)
+            atomic_write_parquet(df, file_path, storage_options=storage_options)
             if verbose:
                 logger.debug(
                     f"Set acquisition={acquisition} on {project}/{filename}"
@@ -303,8 +308,15 @@ def add_acquisition_column(
         dry_run: Whether to preview without modifying files.
         verbose: Whether to print per-file details.
     """
+    storage_options = None
     if is_s3_path(input_dir):
         setup_aws_credentials(aws_profile)
+        storage_options = get_storage_options(aws_profile)
+        if not storage_options:
+            raise ValueError(
+                "S3 input requires --aws-profile with aws_access_key_id, "
+                "aws_secret_access_key, and aws_region in the AWS config"
+            )
 
     data_files = find_data_files_in_folder(input_dir, aws_profile)
     logger.info(f"Found {len(data_files)} data files to process")
@@ -334,7 +346,13 @@ def add_acquisition_column(
             continue
 
         outcome = _process_data_file_with_acquisition(
-            file_path, project, filename, acquisition, dry_run, verbose
+            file_path,
+            project,
+            filename,
+            acquisition,
+            dry_run,
+            verbose,
+            storage_options=storage_options,
         )
         if outcome == "updated":
             updated_count += 1

--- a/scripts/preprocessing/add_acquisition_column.py
+++ b/scripts/preprocessing/add_acquisition_column.py
@@ -23,7 +23,7 @@ from tqdm import tqdm
 
 from scripts.logging_setup import configure_script_logging
 from scripts.paths import DEFAULT_SEARCH_DATA
-from scripts.preprocessing.parquet_io import search_data_lookup_key
+from scripts.preprocessing.parquet_io import atomic_write_parquet, search_data_lookup_key
 
 logger = logging.getLogger(__name__)
 
@@ -247,25 +247,38 @@ def _process_data_file_with_acquisition(
         df = pl.read_parquet(file_path)
 
         if "acquisition" in df.columns:
-            if verbose:
-                existing_value = df["acquisition"][0] if len(df) > 0 else None
-                logger.debug(
-                    f"File {project}/{filename} already has acquisition column "
-                    f"(value: {existing_value})"
-                )
-            return "already_has_column"
+            existing_values = (
+                df["acquisition"].drop_nulls().unique().to_list() if len(df) > 0 else []
+            )
+            if existing_values == [acquisition] or (
+                len(existing_values) == 0 and len(df) == 0
+            ):
+                if verbose:
+                    existing_value = existing_values[0] if existing_values else None
+                    logger.debug(
+                        f"File {project}/{filename} already has acquisition column "
+                        f"(value: {existing_value})"
+                    )
+                return "already_has_column"
+
+            logger.warning(
+                f"File {project}/{filename} acquisition mismatch "
+                f"(existing={existing_values!r}, search_data={acquisition!r}); overwriting"
+            )
 
         df = df.with_columns(pl.lit(acquisition).alias("acquisition"))
 
         if dry_run:
             if verbose:
                 logger.debug(
-                    f"[DRY RUN] Would add acquisition={acquisition} to {project}/{filename}"
+                    f"[DRY RUN] Would set acquisition={acquisition} on {project}/{filename}"
                 )
         else:
-            df.write_parquet(file_path)
+            atomic_write_parquet(df, file_path)
             if verbose:
-                logger.debug(f"Added acquisition={acquisition} to {project}/{filename}")
+                logger.debug(
+                    f"Set acquisition={acquisition} on {project}/{filename}"
+                )
 
         return "updated"
 

--- a/scripts/preprocessing/convert_ipc_to_parquet.py
+++ b/scripts/preprocessing/convert_ipc_to_parquet.py
@@ -71,6 +71,23 @@ app = typer.Typer(
     add_completion=False,
 )
 
+DEFAULT_COLUMN_MAPPING: dict[str, str] = {
+    "rt": "retention_time",
+    "mz": "mz_array",
+    "intensity": "intensity_array",
+    "peptide": "unmodified_peptide",
+}
+
+
+def resolve_column_mapping(
+    overrides: Optional[dict[str, str]] = None,
+) -> dict[str, str]:
+    """Merge user overrides onto the shared default mapping without dropping keys."""
+    mapping = dict(DEFAULT_COLUMN_MAPPING)
+    if overrides:
+        mapping.update(overrides)
+    return mapping
+
 
 def parquet_path_for_ipc_shard(
     ipc_path: str | Path, shard_counter: int, num_shards: int
@@ -245,12 +262,7 @@ def convert_ipc_to_parquet(
         typer.BadParameter: If the requested search-data workbook does not exist.
     """
     if column_mapping is None:
-        column_mapping = {
-            "rt": "retention_time",
-            "mz": "mz_array",
-            "intensity": "intensity_array",
-            "peptide": "unmodified_peptide",
-        }
+        column_mapping = resolve_column_mapping()
 
     logger.debug(f"Source directory: {source_dir}")
     logger.debug(f"Input file: {input_file}")
@@ -478,20 +490,15 @@ def main(
     """Convert IPC files to Parquet from a directory and/or path lists."""
     configure_script_logging(verbose=verbose)
 
-    parsed_column_mapping = None
+    parsed_overrides = None
     if column_mapping:
         try:
-            parsed_column_mapping = json.loads(column_mapping)
+            parsed_overrides = json.loads(column_mapping)
         except json.JSONDecodeError:
             typer.echo("Error: Invalid JSON format for column mapping", err=True)
             raise typer.Exit(1)
 
-    if not parsed_column_mapping:
-        parsed_column_mapping = {
-            "rt": "retention_time",
-            "mz": "mz_array",
-            "intensity": "intensity_array",
-        }
+    parsed_column_mapping = resolve_column_mapping(parsed_overrides)
 
     input_files = input_file or []
     if input_dir is None and not input_files:

--- a/scripts/preprocessing/convert_ipc_to_parquet.py
+++ b/scripts/preprocessing/convert_ipc_to_parquet.py
@@ -183,33 +183,31 @@ def convert_ipc_with_metadata(
 
     lazy_frame = pl.scan_ipc(ipc_path)
     original_file_length = lazy_frame.select(pl.len()).collect().item()
-    # Naming denominator preserved from the previous implementation for
-    # byte-identical output filenames.
-    num_shards = original_file_length // max_shard_size + 1
+    if original_file_length == 0:
+        raise ValueError(f"IPC file is empty: {ipc_path}")
 
-    first_parquet = parquet_path_for_ipc_shard(ipc_path, 0, num_shards)
+    # ceil(len / max). Filename denominator must match files written so
+    # check_conversion accepts exact multiples of max_shard_size.
+    n_shards = (original_file_length + max_shard_size - 1) // max_shard_size
+
+    first_parquet = parquet_path_for_ipc_shard(ipc_path, 0, n_shards)
     lookup_key = extract_file_name(str(first_parquet))
     acquisition = acquisition_map.get((project, lookup_key))
     if acquisition is None:
         raise ValueError(f"No acquisition in search data for {project}/{lookup_key}")
 
     column_mapping = column_mapping or {}
-    # Number of shards actually written == ceil(len / max), matching the count
-    # yielded by the previous get_data_shards path (min 1 for empty files).
-    n_shards_to_write = max(
-        1, (original_file_length + max_shard_size - 1) // max_shard_size
-    )
     if verbose:
         logger.debug(
-            f"{ipc_path}: {original_file_length:,} rows -> {n_shards_to_write} shard(s)"
+            f"{ipc_path}: {original_file_length:,} rows -> {n_shards} shard(s)"
         )
 
-    for shard_counter in range(n_shards_to_write):
+    for shard_counter in range(n_shards):
         shard = lazy_frame.slice(
             shard_counter * max_shard_size, max_shard_size
         ).collect()
         shard = _prepare_ipc_shard(shard, column_mapping)
-        parquet_path = parquet_path_for_ipc_shard(ipc_path, shard_counter, num_shards)
+        parquet_path = parquet_path_for_ipc_shard(ipc_path, shard_counter, n_shards)
         enriched = enrich_acfm_metadata(
             shard, parquet_path, acquisition, add_usi=add_usi
         )
@@ -389,6 +387,8 @@ def process_ipc_files(
                         add_usi=add_usi,
                     )
                 else:
+                    if pl.scan_ipc(ipc_path).select(pl.len()).collect().item() == 0:
+                        raise ValueError(f"IPC file is empty: {ipc_path}")
                     SpectrumDataFrame.load(
                         ipc_path,
                         column_mapping=column_mapping,

--- a/scripts/preprocessing/delete_files.py
+++ b/scripts/preprocessing/delete_files.py
@@ -32,6 +32,12 @@ app = typer.Typer(
 )
 
 
+def expansion_targets(file_path: str) -> list[str]:
+    """Expand a list entry to the IPC and Parquet paths a real delete would unlink."""
+    base_path = file_path.rsplit(".", 1)[0]
+    return [base_path + ".ipc", base_path + ".parquet"]
+
+
 def delete_files_from_list(
     file_list_path: str, error_log_path: str, dry_run: bool = False
 ) -> None:
@@ -50,38 +56,39 @@ def delete_files_from_list(
         raise typer.Exit(1)
 
     with open(file_list_path, "r") as f:
-        files_to_delete = [line.strip() for line in f.readlines()]
+        files_to_delete = [line.strip() for line in f.readlines() if line.strip()]
+
+    expanded = [
+        target
+        for file_path in files_to_delete
+        for target in expansion_targets(file_path)
+    ]
 
     if dry_run:
         logger.info("DRY RUN - The following files would be deleted:")
-        for file_path in files_to_delete:
+        for file_path in expanded:
             logger.info(f"  {file_path}")
-        logger.info(f"Total: {len(files_to_delete)} files")
+        logger.info(f"Total: {len(expanded)} files")
         return
 
     error_log = Path(error_log_path)
     error_log.parent.mkdir(parents=True, exist_ok=True)
 
     with open(error_log, "a") as error_log_file:
-        for file_path in files_to_delete:
-            base_path = file_path.rsplit(".", 1)[0]
-            ipc_file = base_path + ".ipc"
-            parquet_file = base_path + ".parquet"
-
-            for file in [ipc_file, parquet_file]:
-                file_path_obj = Path(file)
-                if file_path_obj.exists():
-                    try:
-                        file_path_obj.unlink()
-                        logger.info(f"Deleted file: {file}")
-                    except Exception as e:
-                        error_message = f"Error deleting file {file}: {e}\n"
-                        logger.error(error_message.strip())
-                        error_log_file.write(error_message)
-                else:
-                    warning_message = f"File not found, skipping: {file}\n"
-                    logger.warning(warning_message.strip())
-                    error_log_file.write(warning_message)
+        for file in expanded:
+            file_path_obj = Path(file)
+            if file_path_obj.exists():
+                try:
+                    file_path_obj.unlink()
+                    logger.info(f"Deleted file: {file}")
+                except Exception as e:
+                    error_message = f"Error deleting file {file}: {e}\n"
+                    logger.error(error_message.strip())
+                    error_log_file.write(error_message)
+            else:
+                warning_message = f"File not found, skipping: {file}\n"
+                logger.warning(warning_message.strip())
+                error_log_file.write(warning_message)
 
 
 @app.command()

--- a/scripts/preprocessing/delete_multi_folder_duplicates.py
+++ b/scripts/preprocessing/delete_multi_folder_duplicates.py
@@ -110,10 +110,11 @@ def parse_files_to_delete(input_file: str, target_folder: str) -> list:
             current_file = line.split("File: ")[1]
         elif line.startswith("-"):
             folder = line.split("- ")[1]
-            if target_folder in folder and current_file:
-                files_to_delete.append(
-                    os.path.join(folder, current_file) + ".mzML.ipc"
-                )  # TODO: patch this suffix addition better
+            if folder == target_folder and current_file:
+                for suffix in (".mzML.ipc", ".ipc"):
+                    candidate = os.path.join(folder, current_file) + suffix
+                    if os.path.exists(candidate):
+                        files_to_delete.append(candidate)
     return files_to_delete
 
 

--- a/scripts/preprocessing/delete_same_folder_duplicates.py
+++ b/scripts/preprocessing/delete_same_folder_duplicates.py
@@ -124,11 +124,11 @@ def find_duplicates_to_delete(file_map: defaultdict) -> list:
         for _folder, file_paths in folder_groups.items():
             if len(file_paths) > 1:
                 file_paths.sort()
-                second_file = file_paths[1]
-                files_to_delete.append(second_file)
-                parquet_file = second_file.rsplit(".", maxsplit=1)[0] + ".parquet"
-                if os.path.exists(parquet_file):
-                    files_to_delete.append(parquet_file)
+                for redundant in file_paths[1:]:
+                    files_to_delete.append(redundant)
+                    parquet_file = redundant.rsplit(".", maxsplit=1)[0] + ".parquet"
+                    if os.path.exists(parquet_file):
+                        files_to_delete.append(parquet_file)
 
     return files_to_delete
 

--- a/scripts/preprocessing/delete_same_folder_duplicates.py
+++ b/scripts/preprocessing/delete_same_folder_duplicates.py
@@ -24,6 +24,7 @@ from typing import Annotated, List
 import typer
 
 from scripts.logging_setup import configure_script_logging
+from scripts.preprocessing.parquet_io import strip_known_data_suffix
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +100,7 @@ def parse_input_file(input_file: str) -> defaultdict:
             line = line.strip()
             if line:
                 folder, file_name = os.path.split(line)
-                base_name = file_name.rsplit(".", maxsplit=2)[0]
+                base_name = strip_known_data_suffix(file_name)
                 file_map[base_name].append((folder, line))
 
     return file_map

--- a/scripts/preprocessing/detect_all_duplicates.py
+++ b/scripts/preprocessing/detect_all_duplicates.py
@@ -22,6 +22,7 @@ from typing import Annotated, Dict, List, Optional
 import typer
 
 from scripts.logging_setup import configure_script_logging
+from scripts.preprocessing.parquet_io import strip_known_data_suffix
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +73,7 @@ def group_files_by_base_name(
     for root, _, files in os.walk(source_dir):
         for file in files:
             if any(file.endswith(ext) for ext in extensions):
-                base_name = file.split(".")[0]
+                base_name = strip_known_data_suffix(file)
                 if base_name not in file_dict:
                     file_dict[base_name] = []
                 file_dict[base_name].append(os.path.join(root, file))

--- a/scripts/preprocessing/detect_all_duplicates.py
+++ b/scripts/preprocessing/detect_all_duplicates.py
@@ -33,35 +33,45 @@ app = typer.Typer(
 
 
 def find_duplicate_files(
-    source_dir: str, output_file: str = "duplicate_files.txt"
+    source_dir: str,
+    output_file: str = "duplicate_files.txt",
+    extensions: Optional[List[str]] = None,
 ) -> None:
     """Create the candidate report needed for safe duplicate classification.
 
-    Files sharing a basename across ``.ipc`` and ``.mzML.ipc`` variants are
-    treated as candidates.
+    Files sharing a basename across configured extensions are treated as
+    candidates (default ``.ipc`` / ``.mzML.ipc``).
 
     Args:
         source_dir: Directory tree to inspect.
         output_file: Destination for grouped duplicate paths.
+        extensions: Filename suffixes to include.
     """
-    file_dict = group_files_by_base_name(source_dir)
+    file_dict = group_files_by_base_name(source_dir, extensions=extensions)
     duplicates = identify_duplicates(file_dict)
     save_duplicates(output_file, duplicates)
 
 
-def group_files_by_base_name(source_dir: str) -> Dict[str, List[str]]:
+def group_files_by_base_name(
+    source_dir: str,
+    extensions: Optional[List[str]] = None,
+) -> Dict[str, List[str]]:
     """Preserve every candidate path so duplicate groups can be classified later.
 
     Args:
-        source_dir: Directory tree containing IPC variants.
+        source_dir: Directory tree containing candidate files.
+        extensions: Filename suffixes to include; defaults to ``.ipc`` / ``.mzML.ipc``.
 
     Returns:
         Mapping from experiment basename to matching paths.
     """
+    if extensions is None:
+        extensions = [".ipc", ".mzML.ipc"]
+
     file_dict: Dict[str, List[str]] = {}
     for root, _, files in os.walk(source_dir):
         for file in files:
-            if file.endswith(".ipc") or file.endswith(".mzML.ipc"):
+            if any(file.endswith(ext) for ext in extensions):
                 base_name = file.split(".")[0]
                 if base_name not in file_dict:
                     file_dict[base_name] = []
@@ -120,7 +130,7 @@ def main(
         typer.Option(
             "--extensions",
             "-e",
-            help="File extensions retained for CLI compatibility",
+            help="File extensions to include (default: .ipc .mzML.ipc)",
         ),
     ] = None,
     verbose: Annotated[
@@ -152,7 +162,7 @@ def main(
     all_duplicates: List[List[str]] = []
     for directory in valid_dirs:
         logger.debug(f"Searching for duplicates in: {directory}")
-        file_dict = group_files_by_base_name(str(directory))
+        file_dict = group_files_by_base_name(str(directory), extensions=extensions)
         all_duplicates.extend(identify_duplicates(file_dict))
 
     save_duplicates(str(output_file), all_duplicates)

--- a/scripts/preprocessing/detect_multi_folder_duplicates.py
+++ b/scripts/preprocessing/detect_multi_folder_duplicates.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import Annotated, List
+from typing import Annotated, Dict, List
 
 import typer
 
@@ -30,6 +30,57 @@ app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
 )
+
+
+def parse_duplicate_report(input_file: str | Path) -> Dict[str, List[str]]:
+    """Map experiment basenames to unique parent folders from a duplicate report.
+
+    Same-folder ``.ipc`` / ``.mzML.ipc`` pairs share one folder and must not be
+    treated as multi-folder duplicates.
+
+    Args:
+        input_file: Duplicate report from ``detect_all_duplicates.py``.
+
+    Returns:
+        Basename to unique folder list (order preserved).
+    """
+    file_map: Dict[str, List[str]] = defaultdict(list)
+    with open(input_file, "r") as infile:
+        for line in infile:
+            line = line.strip()
+            if not line:
+                continue
+            folder, file_name = line.rsplit("/", 1)
+            base_name = file_name.split(".", 1)[0]
+            if folder not in file_map[base_name]:
+                file_map[base_name].append(folder)
+    return dict(file_map)
+
+
+def classify_multi_folder_duplicates(
+    file_map: Dict[str, List[str]],
+) -> Dict[str, List[str]]:
+    """Keep only basenames that appear under more than one distinct folder."""
+    return {
+        base_name: folders
+        for base_name, folders in file_map.items()
+        if len(folders) > 1
+    }
+
+
+def write_multi_folder_report(
+    duplicates: Dict[str, List[str]], output_file: str | Path
+) -> None:
+    """Persist cross-folder groups for manual review."""
+    output_path = Path(output_file)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as outfile:
+        for file_name, folders in duplicates.items():
+            outfile.write(f"File: {file_name}\n")
+            outfile.write("Folders:\n")
+            for folder in folders:
+                outfile.write(f"  - {folder}\n")
+            outfile.write("\n")
 
 
 def find_duplicate_files(
@@ -54,33 +105,10 @@ def find_duplicate_files(
         typer.echo(f"Error: Input file '{input_file}' does not exist", err=True)
         raise typer.Exit(1)
 
-    file_map = defaultdict(list)
-
-    with open(input_file, "r") as infile:
-        for line in infile:
-            line = line.strip()
-            if line:
-                folder, file_name = line.rsplit("/", 1)
-                base_name = file_name.split(".", 1)[0]
-                file_map[base_name].append(folder)
-
-    duplicates = {
-        file_name: folders
-        for file_name, folders in file_map.items()
-        if len(folders) > 1
-    }
+    duplicates = classify_multi_folder_duplicates(parse_duplicate_report(input_file))
 
     if duplicates:
-        output_path = Path(output_file)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
-        with open(output_file, "w") as outfile:
-            for file_name, folders in duplicates.items():
-                outfile.write(f"File: {file_name}\n")
-                outfile.write("Folders:\n")
-                for folder in folders:
-                    outfile.write(f"  - {folder}\n")
-                outfile.write("\n")
+        write_multi_folder_report(duplicates, output_file)
         logger.info(f"Duplicate detection report written to {output_file}")
         logger.info(f"Found {len(duplicates)} files with multi-folder duplicates")
     else:
@@ -125,37 +153,19 @@ def main(
         typer.echo("Error: no valid input files", err=True)
         raise typer.Exit(1)
 
-    # Merge classifications from all reports into one output.
     merged: dict = {}
     for path in valid_files:
         logger.debug(f"Processing: {path}")
-        # Write through a temp merge: collect then write once.
-        if not path.exists():
-            continue
-        file_map = defaultdict(list)
-        with open(path, "r") as infile:
-            for line in infile:
-                line = line.strip()
-                if line:
-                    folder, file_name = line.rsplit("/", 1)
-                    base_name = file_name.split(".", 1)[0]
-                    file_map[base_name].append(folder)
-        for base_name, folders in file_map.items():
-            if len(folders) > 1:
-                existing = merged.setdefault(base_name, [])
-                for folder in folders:
-                    if folder not in existing:
-                        existing.append(folder)
+        for base_name, folders in classify_multi_folder_duplicates(
+            parse_duplicate_report(path)
+        ).items():
+            existing = merged.setdefault(base_name, [])
+            for folder in folders:
+                if folder not in existing:
+                    existing.append(folder)
 
-    output_file.parent.mkdir(parents=True, exist_ok=True)
     if merged:
-        with open(output_file, "w") as outfile:
-            for file_name, folders in merged.items():
-                outfile.write(f"File: {file_name}\n")
-                outfile.write("Folders:\n")
-                for folder in folders:
-                    outfile.write(f"  - {folder}\n")
-                outfile.write("\n")
+        write_multi_folder_report(merged, output_file)
         logger.info(f"Duplicate detection report written to {output_file}")
         logger.info(f"Found {len(merged)} files with multi-folder duplicates")
     else:

--- a/scripts/preprocessing/detect_multi_folder_duplicates.py
+++ b/scripts/preprocessing/detect_multi_folder_duplicates.py
@@ -22,6 +22,7 @@ from typing import Annotated, Dict, List
 import typer
 
 from scripts.logging_setup import configure_script_logging
+from scripts.preprocessing.parquet_io import strip_known_data_suffix
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ def parse_duplicate_report(input_file: str | Path) -> Dict[str, List[str]]:
             if not line:
                 continue
             folder, file_name = line.rsplit("/", 1)
-            base_name = file_name.split(".", 1)[0]
+            base_name = strip_known_data_suffix(file_name)
             if folder not in file_map[base_name]:
                 file_map[base_name].append(folder)
     return dict(file_map)

--- a/scripts/preprocessing/enforce_nulls.py
+++ b/scripts/preprocessing/enforce_nulls.py
@@ -25,6 +25,7 @@ import typer
 from tqdm import tqdm
 
 from scripts.logging_setup import configure_script_logging
+from scripts.preprocessing.parquet_io import atomic_write_parquet
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +92,7 @@ def _process_parquet_file(
         df = ldf.with_columns(
             [pl.col(col).replace(old_value, new_value) for col in columns_to_update]
         ).collect()
-        df.write_parquet(file)
+        atomic_write_parquet(df, file)
         if verbose:
             logger.debug(
                 f"Updated file: {file} (columns: {', '.join(columns_to_update)})"

--- a/scripts/preprocessing/find_empty_files.py
+++ b/scripts/preprocessing/find_empty_files.py
@@ -28,7 +28,7 @@ from scripts.logging_setup import configure_script_logging
 logger = logging.getLogger(__name__)
 
 app = typer.Typer(
-    help="Find empty or small files in local directories",
+    help="Find empty IPC files in local directories",
     no_args_is_help=True,
     add_completion=False,
 )
@@ -65,10 +65,9 @@ def check_if_empty(file_path: str, flagged_files: list[str]) -> list[str]:
     return flagged_files
 
 
-def flag_small_files_in_dir(
+def flag_empty_files_in_dir(
     source_dir: str,
     file_pattern: str = "**/*.ipc",
-    min_size_bytes: int = 0,
     verbose: bool = False,
 ) -> list[str]:
     """Scan one directory and return paths of empty IPC files.
@@ -76,7 +75,6 @@ def flag_small_files_in_dir(
     Args:
         source_dir: Directory tree containing IPC files.
         file_pattern: Glob selecting files to inspect.
-        min_size_bytes: Requested size threshold retained for CLI compatibility.
         verbose: Whether to print scan details.
 
     Returns:
@@ -88,7 +86,6 @@ def flag_small_files_in_dir(
 
     logger.debug(f"Searching for files in: {source_dir}")
     logger.debug(f"File pattern: {file_pattern}")
-    logger.debug(f"Minimum size: {min_size_bytes} bytes")
 
     matched_files = find_files(input_dir=source_dir, file_pattern=file_pattern)
 
@@ -128,16 +125,12 @@ def main(
         str,
         typer.Option("--pattern", help="File pattern to match"),
     ] = "**/*.ipc",
-    min_size: Annotated[
-        int,
-        typer.Option("--min-size", help="Minimum file size in bytes (CLI compatibility)"),
-    ] = 0,
     verbose: Annotated[
         bool,
         typer.Option("--verbose", "-v", help="Enable verbose output"),
     ] = False,
 ) -> None:
-    """Report unusable IPC files before conversion."""
+    """Report empty IPC files before conversion."""
     configure_script_logging(verbose=verbose)
 
     logger.debug(f"Output file: {output_file}")
@@ -149,10 +142,9 @@ def main(
             continue
         logger.info(f"Checking empty files in: {directory}")
         all_flagged.extend(
-            flag_small_files_in_dir(
+            flag_empty_files_in_dir(
                 source_dir=str(directory),
                 file_pattern=pattern,
-                min_size_bytes=min_size,
                 verbose=verbose,
             )
         )

--- a/scripts/preprocessing/infer_isolation_target.py
+++ b/scripts/preprocessing/infer_isolation_target.py
@@ -25,7 +25,7 @@ import typer
 from tqdm import tqdm
 
 from scripts.logging_setup import configure_script_logging
-from scripts.preprocessing.parquet_io import nan_string_to_null_expr
+from scripts.preprocessing.parquet_io import atomic_write_parquet, nan_string_to_null_expr
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +146,7 @@ def process_single_file(file_path: str, verbose: bool = False) -> tuple[bool, bo
 
     # Write the new dataframe to the file.
     df = query.collect()
-    df.write_parquet(file_path)
+    atomic_write_parquet(df, file_path)
 
     return True, False
 

--- a/scripts/preprocessing/label_modifications.py
+++ b/scripts/preprocessing/label_modifications.py
@@ -67,6 +67,7 @@ from tqdm import tqdm
 
 from scripts.logging_setup import configure_script_logging
 from scripts.paths import DEFAULT_AMBIGUOUS_MODS, DEFAULT_GOLD_STANDARD_MODS
+from scripts.preprocessing.parquet_io import atomic_write_parquet
 
 logger = logging.getLogger(__name__)
 
@@ -447,7 +448,7 @@ def create_unimod_column(
             df = df.drop([modified_sequence_col])
         if sequence_col != "unmodified_peptide":
             df = df.drop([sequence_col])
-        df.collect().write_parquet(file)
+        atomic_write_parquet(df.collect(), file)
 
 
 @app.command()

--- a/scripts/preprocessing/parquet_io.py
+++ b/scripts/preprocessing/parquet_io.py
@@ -101,6 +101,8 @@ def experiment_name_from_path(path_str: str) -> str:
 
 
 _COMPOUND_SUFFIXES = (".mzml.ipc", ".mzml.gz", ".mzml.parquet")
+# Longest known data suffixes first so ``sample.mzML.ipc`` is not truncated to ``sample.mzML``.
+_KNOWN_DATA_SUFFIXES = (".mzml.ipc", ".parquet", ".ipc")
 
 
 def search_data_lookup_key(path_str: str) -> str:
@@ -120,6 +122,26 @@ def search_data_lookup_key(path_str: str) -> str:
         if name.lower().endswith(suffix):
             return normalize_experiment_stem(name[: -len(suffix)])
     return normalize_experiment_stem(Path(name).stem)
+
+
+def strip_known_data_suffix(filename: str) -> str:
+    """Identify an experiment by removing only known data-file suffixes.
+
+    Dotted names such as ``run.v1.ipc`` stay ``run.v1`` instead of collapsing
+    to ``run``.
+
+    Args:
+        filename: Basename or path of a candidate data file.
+
+    Returns:
+        Experiment identity used for duplicate grouping.
+    """
+    name = Path(filename).name
+    lower = name.lower()
+    for suffix in _KNOWN_DATA_SUFFIXES:
+        if lower.endswith(suffix):
+            return name[: -len(suffix)]
+    return Path(name).stem
 
 
 def parse_shard_suffix(filename: str) -> Optional[Tuple[int, int]]:

--- a/scripts/preprocessing/parquet_io.py
+++ b/scripts/preprocessing/parquet_io.py
@@ -7,6 +7,7 @@ module is imported; it has no CLI.
 
 from __future__ import annotations
 
+import configparser
 import os
 import re
 import tempfile
@@ -258,13 +259,109 @@ def nan_string_to_null_expr(column: str) -> pl.Expr:
     )
 
 
-def atomic_write_parquet(df: pl.DataFrame, file_path: Path | str) -> None:
+def _find_aws_dir() -> str:
+    """Prefer a checkout ``.aws`` directory when present, otherwise the user home config."""
+    repo_root = Path(__file__).resolve().parents[2]
+    checkout = repo_root / ".aws"
+    if checkout.is_dir():
+        return str(checkout)
+    return os.path.expanduser("~/.aws")
+
+
+def _read_aws_credentials(aws_dir: str, profile: str, storage_opts: dict) -> None:
+    """Load access keys into Polars storage options for S3 I/O."""
+    creds_file = os.path.join(aws_dir, "credentials")
+    if not os.path.exists(creds_file):
+        return
+
+    creds = configparser.ConfigParser()
+    creds.read(creds_file)
+    if profile not in creds:
+        return
+
+    if "aws_access_key_id" in creds[profile]:
+        storage_opts["aws_access_key_id"] = creds[profile]["aws_access_key_id"]
+    if "aws_secret_access_key" in creds[profile]:
+        storage_opts["aws_secret_access_key"] = creds[profile]["aws_secret_access_key"]
+
+
+def _read_aws_config(aws_dir: str, profile: str, storage_opts: dict) -> None:
+    """Load region into Polars storage options for S3 I/O."""
+    config_file = os.path.join(aws_dir, "config")
+    if not os.path.exists(config_file):
+        return
+
+    config = configparser.ConfigParser()
+    config.read(config_file)
+    profile_section = f"profile {profile}"
+    if profile_section in config and "region" in config[profile_section]:
+        storage_opts["aws_region"] = config[profile_section]["region"]
+
+
+def get_storage_options(aws_profile: Optional[str] = None) -> Optional[dict]:
+    """Build Polars S3 storage options from a named AWS profile.
+
+    Args:
+        aws_profile: Profile to read, or None for local files.
+
+    Returns:
+        Storage options dict, or None when unused or empty.
+    """
+    if not aws_profile:
+        return None
+
+    storage_opts: dict = {}
+    aws_dir = _find_aws_dir()
+    _read_aws_credentials(aws_dir, aws_profile, storage_opts)
+    _read_aws_config(aws_dir, aws_profile, storage_opts)
+    return storage_opts if storage_opts else None
+
+
+def _remote_parquet_uri(file_path: Path | str) -> Optional[str]:
+    """Return an ``s3://`` URI, or None for a local filesystem path."""
+    text = file_path if isinstance(file_path, str) else os.fspath(file_path)
+    if text.startswith("s3://"):
+        return text
+    # pathlib.Path("s3://bucket/key") becomes "s3:/bucket/key" on POSIX.
+    if text.startswith("s3:/"):
+        return "s3://" + text[len("s3:/") :]
+    return None
+
+
+def atomic_write_parquet(
+    df: pl.DataFrame,
+    file_path: Path | str,
+    storage_options: Optional[dict] = None,
+) -> None:
     """Avoid leaving a partial Parquet file when serialisation fails.
+
+    ``s3://`` destinations are written with Polars cloud I/O and require the
+    same profile-derived ``storage_options`` used for S3 reads.
 
     Args:
         df: Materialised table to persist.
-        file_path: Final Parquet destination.
+        file_path: Final Parquet destination (local path or ``s3://`` URI).
+        storage_options: Polars S3 options (access keys and region). Required
+            for remote URIs.
+
+    Raises:
+        ValueError: If a remote URI is given without profile-derived storage options.
+        OSError: If a remote write fails.
     """
+    remote_uri = _remote_parquet_uri(file_path)
+    if remote_uri is not None:
+        if not storage_options:
+            raise ValueError(
+                f"Refusing to write {remote_uri}: Polars storage_options from "
+                "--aws-profile are required (aws_access_key_id, "
+                "aws_secret_access_key, aws_region)"
+            )
+        try:
+            df.write_parquet(remote_uri, storage_options=storage_options)
+        except Exception as exc:
+            raise OSError(f"Failed to write Parquet to {remote_uri}") from exc
+        return
+
     path = Path(file_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     temp_fd, temp_path_str = tempfile.mkstemp(suffix=".parquet", dir=path.parent)

--- a/scripts/splitting/create_subsets.py
+++ b/scripts/splitting/create_subsets.py
@@ -272,6 +272,12 @@ def main(
         df = normalise_dataframe_schema(df, get_reference_schema())
 
         df = _filter_out_glyco_sequences(df, hold_back)
+        if df.height == 0:
+            logger.debug(
+                f"Skipping {subfolder}/{name}: no rows left after hold-back filter"
+            )
+            continue
+
         scored = with_composite_score(df)
         filtered_df_mcfm = _drop_temp_scoring_columns(
             scored.filter(pl.col("_composite_score") > threshold_mcfm)

--- a/scripts/verification/add_usi_column.py
+++ b/scripts/verification/add_usi_column.py
@@ -21,9 +21,7 @@ CLI::
 from __future__ import annotations
 
 import logging
-import os
 import re
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, List, Optional
@@ -36,7 +34,7 @@ from scripts.verification.verify_calc_mz import (
     find_parquet_files_in_project,
     find_project_folders,
 )
-from scripts.preprocessing.parquet_io import search_data_lookup_key
+from scripts.preprocessing.parquet_io import atomic_write_parquet, search_data_lookup_key
 
 from scripts.logging_setup import configure_script_logging
 
@@ -213,20 +211,6 @@ class AddUsiStats:
     projects_missing_dir: int = 0
 
 
-def _atomic_write_parquet(df: pl.DataFrame, file_path: Path) -> None:
-    """Replace the parquet only after a full write so a crash cannot leave a truncated file."""
-    temp_fd, temp_path_str = tempfile.mkstemp(suffix=".parquet", dir=file_path.parent)
-    os.close(temp_fd)
-    temp_path = Path(temp_path_str)
-    try:
-        df.write_parquet(temp_path)
-        os.replace(temp_path, file_path)
-    except Exception:
-        if temp_path.exists():
-            temp_path.unlink()
-        raise
-
-
 def _add_usi_series(
     df: pl.DataFrame, default_filepath: str, scan_identifier_type: str
 ) -> pl.Series:
@@ -289,7 +273,7 @@ def process_parquet_file(
         logger.info("[DRY-RUN] Would write usi for %s (%d rows)", file_path, len(out))
         return
 
-    _atomic_write_parquet(out, file_path)
+    atomic_write_parquet(out, file_path)
     logger.info("Wrote usi column: %s (%d rows)", file_path, len(out))
 
 

--- a/scripts/verification/apply_carbamido_from_calc_mz_report.py
+++ b/scripts/verification/apply_carbamido_from_calc_mz_report.py
@@ -27,8 +27,6 @@ CLI::
 from __future__ import annotations
 
 import logging
-import os
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, cast
@@ -42,6 +40,7 @@ from scripts.verification.verify_calc_mz import (
 )
 
 from scripts.logging_setup import configure_script_logging
+from scripts.preprocessing.parquet_io import atomic_write_parquet
 
 app = typer.Typer(
     help="Apply implicit carbamidomethylation from verify_calc_mz report",
@@ -140,20 +139,6 @@ def _carb_sequence(seq: Optional[str]) -> Optional[str]:
     return cast(str, carbamidomethylate_cysteines(seq))
 
 
-def _atomic_write_parquet(df: pl.DataFrame, file_path: Path) -> None:
-    """Replace the parquet only after a full write so a crash cannot leave a truncated file."""
-    temp_fd, temp_path_str = tempfile.mkstemp(suffix=".parquet", dir=file_path.parent)
-    os.close(temp_fd)
-    temp_path = Path(temp_path_str)
-    try:
-        df.write_parquet(temp_path)
-        os.replace(temp_path, file_path)
-    except Exception:
-        if temp_path.exists():
-            temp_path.unlink()
-        raise
-
-
 def _low_or_null_charge_mask(df: pl.DataFrame) -> Optional[pl.Series]:
     """Count carbamidomethylation rewrites on DIA-like (null/<=0 charge) rows that verify_calc_mz does not score."""
     if "precursor_charge" not in df.columns:
@@ -223,7 +208,7 @@ def process_parquet_file(
         return
 
     out = df.with_columns(new_sequence.alias("sequence"))
-    _atomic_write_parquet(out, file_path)
+    atomic_write_parquet(out, file_path)
     logger.info(
         "Updated %s (%d rows, %d with precursor_charge null or <= 0)",
         file_path,

--- a/scripts/verification/apply_tmt_itraq_from_search_data.py
+++ b/scripts/verification/apply_tmt_itraq_from_search_data.py
@@ -43,9 +43,7 @@ CLI::
 from __future__ import annotations
 
 import logging
-import os
 import re
-import tempfile
 from dataclasses import dataclass
 from functools import partial
 from enum import Enum
@@ -58,7 +56,7 @@ import yaml
 
 from scripts.logging_setup import configure_script_logging
 from scripts.paths import DEFAULT_SEARCH_DATA
-from scripts.preprocessing.parquet_io import search_data_lookup_key
+from scripts.preprocessing.parquet_io import atomic_write_parquet, search_data_lookup_key
 from scripts.verification.verify_calc_mz import (
     find_parquet_files_in_project,
     is_tmt_quant,
@@ -435,20 +433,6 @@ def log_quant_summary(project: str, summary: QuantSummary) -> None:
     )
 
 
-def _atomic_write_parquet(df: pl.DataFrame, file_path: Path) -> None:
-    """Replace the parquet only after a full write so a crash cannot leave a truncated file."""
-    temp_fd, temp_path_str = tempfile.mkstemp(suffix=".parquet", dir=file_path.parent)
-    os.close(temp_fd)
-    temp_path = Path(temp_path_str)
-    try:
-        df.write_parquet(temp_path)
-        os.replace(temp_path, file_path)
-    except Exception:
-        if temp_path.exists():
-            temp_path.unlink()
-        raise
-
-
 def _label_sequence(seq: Optional[str], unimod_id: str) -> Optional[str]:
     """Leave null sequences untouched while tagging unmodified lysines on valid peptides."""
     if seq is None:
@@ -488,7 +472,7 @@ def process_parquet_file(
         logger.info("[DRY-RUN] Would update %s (%d rows)", file_path, n_changed)
         return (1, n_changed)
     out = df.with_columns(new_seq.alias("sequence"))
-    _atomic_write_parquet(out, file_path)
+    atomic_write_parquet(out, file_path)
     logger.info("Updated %s (%d rows)", file_path, n_changed)
     return (1, n_changed)
 

--- a/scripts/verification/verify_precursor_charges_and_acq_type.py
+++ b/scripts/verification/verify_precursor_charges_and_acq_type.py
@@ -417,7 +417,7 @@ def load_aquisitions_from_search_data(
         .unique()
     )
 
-    logger.info(f"Found {len(dda_projects)} DIA files in search data")
+    logger.info(f"Found {len(dda_projects)} DDA files in search data")
 
     check_conflicting_acquistions(dia_df=dia_projects, dda_df=dda_projects)
 
@@ -433,6 +433,40 @@ class FilePrecursorChargeErrors:
     error_type: str
     num_error_rows: int
     total_rows: int
+
+
+FILE_PRECURSOR_CHARGE_ERROR_SCHEMA: dict[str, pl.DataType] = {
+    "filename": pl.String,
+    "project": pl.String,
+    "error_type": pl.String,
+    "num_error_rows": pl.Int64,
+    "total_rows": pl.Int64,
+}
+
+
+def errors_to_dataframe(
+    errors: List[FilePrecursorChargeErrors],
+) -> pl.DataFrame:
+    """Keep empty DIA/DDA sides schema-compatible for concat and CSV writes.
+
+    ``pl.DataFrame([])`` has no columns, so concatenating with a non-empty
+    sibling fails when only one acquisition type has issues.
+    """
+    if not errors:
+        return pl.DataFrame(schema=FILE_PRECURSOR_CHARGE_ERROR_SCHEMA)
+    return pl.DataFrame(
+        [
+            {
+                "filename": e.filename,
+                "project": e.project,
+                "error_type": e.error_type,
+                "num_error_rows": e.num_error_rows,
+                "total_rows": e.total_rows,
+            }
+            for e in errors
+        ],
+        schema=FILE_PRECURSOR_CHARGE_ERROR_SCHEMA,
+    )
 
 
 def _check_dda_file_precursor_charges(
@@ -720,8 +754,8 @@ def analyze_precursor_charges(
                 )
             )
 
-    incorrect_dia_df = pl.DataFrame(incorrect_dia_files)
-    incorrect_dda_df = pl.DataFrame(incorrect_dda_files)
+    incorrect_dia_df = errors_to_dataframe(incorrect_dia_files)
+    incorrect_dda_df = errors_to_dataframe(incorrect_dda_files)
 
     project_level_summary = check_if_all_files_in_project_have_errors(
         data_files, incorrect_dia_df, incorrect_dda_df, search_data_files

--- a/scripts/verification/verify_precursor_charges_and_acq_type.py
+++ b/scripts/verification/verify_precursor_charges_and_acq_type.py
@@ -41,7 +41,7 @@ import typer
 
 from scripts.logging_setup import configure_script_logging
 from scripts.paths import DEFAULT_SEARCH_DATA
-from scripts.preprocessing.parquet_io import search_data_lookup_key
+from scripts.preprocessing.parquet_io import get_storage_options, search_data_lookup_key
 
 app = typer.Typer(
     help="Verify precursor charges against acquisition type",
@@ -227,72 +227,6 @@ def find_data_files_in_folder(
                 if file.endswith(".parquet"):
                     data_files.append(os.path.join(root, file))
         return data_files
-
-
-def _find_aws_dir() -> str:
-    """Prefer a checkout ``.aws`` directory when present, otherwise the user home config."""
-    repo_root = os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    )
-    aws_dir = os.path.join(repo_root, ".aws")
-    if os.path.isdir(aws_dir):
-        return aws_dir
-    return os.path.expanduser("~/.aws")
-
-
-def _read_aws_credentials(aws_dir: str, profile: str, storage_opts: dict) -> None:
-    """Load access keys into Polars storage options for S3 reads."""
-    import configparser
-
-    creds_file = os.path.join(aws_dir, "credentials")
-    if not os.path.exists(creds_file):
-        return
-
-    creds = configparser.ConfigParser()
-    creds.read(creds_file)
-    if profile not in creds:
-        return
-
-    if "aws_access_key_id" in creds[profile]:
-        storage_opts["aws_access_key_id"] = creds[profile]["aws_access_key_id"]
-    if "aws_secret_access_key" in creds[profile]:
-        storage_opts["aws_secret_access_key"] = creds[profile]["aws_secret_access_key"]
-
-
-def _read_aws_config(aws_dir: str, profile: str, storage_opts: dict) -> None:
-    """Load region into Polars storage options for S3 reads."""
-    import configparser
-
-    config_file = os.path.join(aws_dir, "config")
-    if not os.path.exists(config_file):
-        return
-
-    config = configparser.ConfigParser()
-    config.read(config_file)
-    profile_section = f"profile {profile}"
-    if profile_section in config and "region" in config[profile_section]:
-        storage_opts["aws_region"] = config[profile_section]["region"]
-
-
-def get_storage_options(aws_profile: Optional[str] = None) -> Optional[dict]:
-    """Build Polars S3 storage options from a named AWS profile.
-
-    Args:
-        aws_profile: Profile to read, or None for local files.
-
-    Returns:
-        Storage options dict, or None when unused or empty.
-    """
-    if not aws_profile:
-        return None
-
-    aws_dir = _find_aws_dir()
-    storage_opts: dict = {}
-
-    _read_aws_credentials(aws_dir, aws_profile, storage_opts)
-    _read_aws_config(aws_dir, aws_profile, storage_opts)
-
-    return storage_opts if storage_opts else None
 
 
 def _read_file_lazy(

--- a/tests/scripts/preprocessing/test_add_acquisition_column.py
+++ b/tests/scripts/preprocessing/test_add_acquisition_column.py
@@ -1,0 +1,32 @@
+"""Tests for add_acquisition_column mismatch overwrite."""
+
+from pathlib import Path
+
+import polars as pl
+
+from scripts.preprocessing.add_acquisition_column import (
+    _process_data_file_with_acquisition,
+)
+
+
+def test_mismatch_overwrites_acquisition(tmp_path: Path) -> None:
+    """Stale acquisition values are overwritten from search data."""
+    path = tmp_path / "sample.parquet"
+    pl.DataFrame({"scan": ["1"], "acquisition": ["DIA"]}).write_parquet(path)
+
+    outcome = _process_data_file_with_acquisition(
+        str(path), "PXD000001", "sample", "DDA", dry_run=False, verbose=False
+    )
+    assert outcome == "updated"
+    assert pl.read_parquet(path)["acquisition"].to_list() == ["DDA"]
+
+
+def test_matching_acquisition_is_skipped(tmp_path: Path) -> None:
+    """Matching acquisition values are left alone."""
+    path = tmp_path / "sample.parquet"
+    pl.DataFrame({"scan": ["1"], "acquisition": ["DDA"]}).write_parquet(path)
+
+    outcome = _process_data_file_with_acquisition(
+        str(path), "PXD000001", "sample", "DDA", dry_run=False, verbose=False
+    )
+    assert outcome == "already_has_column"

--- a/tests/scripts/preprocessing/test_convert_ipc_to_parquet.py
+++ b/tests/scripts/preprocessing/test_convert_ipc_to_parquet.py
@@ -1,0 +1,101 @@
+"""Tests for ACFM IPC shard naming during conversion."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from scripts.preprocessing.check_conversion import is_shard_incomplete
+from scripts.preprocessing.convert_ipc_to_parquet import convert_ipc_with_metadata
+
+_SHARD_PATTERN = re.compile(r".+_\d{4}-\d{4}.parquet$")
+
+
+def _minimal_ipc_frame(n_rows: int) -> pl.DataFrame:
+    """Build a small IPC frame with columns conversion can cast and enrich."""
+    return pl.DataFrame(
+        {
+            "scan": [str(i) for i in range(n_rows)],
+            "precursor_mz": [500.0 + i for i in range(n_rows)],
+            "precursor_charge": [2] * n_rows,
+            "mz_array": [[100.0, 200.0]] * n_rows,
+            "intensity_array": [[1.0, 2.0]] * n_rows,
+        }
+    )
+
+
+def _write_ipc(path: Path, n_rows: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _minimal_ipc_frame(n_rows).write_ipc(path)
+
+
+def _parquet_names(ipc_path: Path) -> list[str]:
+    stem = ipc_path.name.replace(".ipc", "")
+    return sorted(
+        p.name
+        for p in ipc_path.parent.iterdir()
+        if p.suffix == ".parquet" and p.name.startswith(stem)
+    )
+
+
+def test_exact_multiple_of_max_shard_size_names_match_count(tmp_path: Path) -> None:
+    """Exact multiples must encode the true shard count in filenames."""
+    project = "PXD000001"
+    ipc_path = tmp_path / project / "sample.mzML.ipc"
+    _write_ipc(ipc_path, n_rows=4)
+
+    convert_ipc_with_metadata(
+        str(ipc_path),
+        acquisition_map={(project, "sample"): "DDA"},
+        max_shard_size=2,
+        add_usi=False,
+    )
+
+    names = _parquet_names(ipc_path)
+    assert names == [
+        "sample.mzML_0000-0002.parquet",
+        "sample.mzML_0001-0002.parquet",
+    ]
+    assert not is_shard_incomplete(names, _SHARD_PATTERN)
+
+
+def test_remainder_shard_names_match_count(tmp_path: Path) -> None:
+    """Non-exact multiples keep ceil(len / max) in both count and names."""
+    project = "PXD000001"
+    ipc_path = tmp_path / project / "sample.mzML.ipc"
+    _write_ipc(ipc_path, n_rows=5)
+
+    convert_ipc_with_metadata(
+        str(ipc_path),
+        acquisition_map={(project, "sample"): "DDA"},
+        max_shard_size=2,
+        add_usi=False,
+    )
+
+    names = _parquet_names(ipc_path)
+    assert names == [
+        "sample.mzML_0000-0003.parquet",
+        "sample.mzML_0001-0003.parquet",
+        "sample.mzML_0002-0003.parquet",
+    ]
+    assert not is_shard_incomplete(names, _SHARD_PATTERN)
+
+
+def test_empty_ipc_raises_and_writes_no_parquet(tmp_path: Path) -> None:
+    """Empty IPC must not produce Parquet; callers log the error and continue."""
+    project = "PXD000001"
+    ipc_path = tmp_path / project / "sample.mzML.ipc"
+    _write_ipc(ipc_path, n_rows=0)
+
+    with pytest.raises(ValueError, match="IPC file is empty"):
+        convert_ipc_with_metadata(
+            str(ipc_path),
+            acquisition_map={(project, "sample"): "DDA"},
+            max_shard_size=2,
+            add_usi=False,
+        )
+
+    assert _parquet_names(ipc_path) == []

--- a/tests/scripts/preprocessing/test_convert_ipc_to_parquet.py
+++ b/tests/scripts/preprocessing/test_convert_ipc_to_parquet.py
@@ -9,7 +9,11 @@ import polars as pl
 import pytest
 
 from scripts.preprocessing.check_conversion import is_shard_incomplete
-from scripts.preprocessing.convert_ipc_to_parquet import convert_ipc_with_metadata
+from scripts.preprocessing.convert_ipc_to_parquet import (
+    DEFAULT_COLUMN_MAPPING,
+    convert_ipc_with_metadata,
+    resolve_column_mapping,
+)
 
 _SHARD_PATTERN = re.compile(r".+_\d{4}-\d{4}.parquet$")
 
@@ -99,3 +103,18 @@ def test_empty_ipc_raises_and_writes_no_parquet(tmp_path: Path) -> None:
         )
 
     assert _parquet_names(ipc_path) == []
+
+
+def test_resolve_column_mapping_defaults_include_peptide() -> None:
+    """Default mapping remaps peptide so labelled IPC conversion stays consistent."""
+    assert resolve_column_mapping() == DEFAULT_COLUMN_MAPPING
+    assert resolve_column_mapping()["peptide"] == "unmodified_peptide"
+
+
+def test_resolve_column_mapping_merges_overrides() -> None:
+    """Partial JSON overrides must not drop other default remaps."""
+    merged = resolve_column_mapping({"rt": "rt_min"})
+    assert merged["rt"] == "rt_min"
+    assert merged["mz"] == "mz_array"
+    assert merged["intensity"] == "intensity_array"
+    assert merged["peptide"] == "unmodified_peptide"

--- a/tests/scripts/preprocessing/test_delete_files.py
+++ b/tests/scripts/preprocessing/test_delete_files.py
@@ -3,7 +3,10 @@
 import polars as pl
 from typer.testing import CliRunner
 
-from scripts.preprocessing.delete_files import app as delete_files_app
+from scripts.preprocessing.delete_files import (
+    app as delete_files_app,
+    expansion_targets,
+)
 
 
 def test_delete_files(preprocessing_env) -> None:
@@ -31,3 +34,31 @@ def test_delete_files(preprocessing_env) -> None:
     assert result.exit_code == 0
     assert not test_file.exists()
     assert error_log.exists()
+
+
+def test_dry_run_previews_ipc_and_parquet_targets(preprocessing_env) -> None:
+    """Dry-run must expand list paths the same way a real delete would."""
+    runner = CliRunner()
+    test_file = preprocessing_env.data_dir / "acfm" / "preview.ipc"
+    pl.DataFrame({"test": [1]}).write_ipc(test_file)
+    parquet = test_file.with_suffix(".parquet")
+    pl.DataFrame({"test": [1]}).write_parquet(parquet)
+
+    file_list = preprocessing_env.output_dir / "preview_list.txt"
+    file_list.write_text(str(test_file) + "\n")
+
+    assert expansion_targets(str(test_file)) == [str(test_file), str(parquet)]
+
+    result = runner.invoke(
+        delete_files_app,
+        [
+            "--input-file",
+            str(file_list),
+            "--dry-run",
+            "--verbose",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert test_file.exists()
+    assert parquet.exists()

--- a/tests/scripts/preprocessing/test_delete_multi_folder_duplicates.py
+++ b/tests/scripts/preprocessing/test_delete_multi_folder_duplicates.py
@@ -1,0 +1,39 @@
+"""Tests for delete_multi_folder_duplicates."""
+
+from pathlib import Path
+
+from scripts.preprocessing.delete_multi_folder_duplicates import parse_files_to_delete
+
+
+def test_exact_folder_match_resolves_existing_ipc_suffixes(tmp_path: Path) -> None:
+    """Exact folder match; resolve .ipc / .mzML.ipc only when they exist."""
+    keep = tmp_path / "keep"
+    drop = tmp_path / "drop"
+    keep.mkdir()
+    drop.mkdir()
+    (drop / "sample.mzML.ipc").write_text("x")
+    (drop / "sample.ipc").write_text("y")
+    # Substring trap: target "drop" must not match "keep_drop_extra"
+    trap = tmp_path / "keep_drop_extra"
+    trap.mkdir()
+    (trap / "sample.mzML.ipc").write_text("z")
+
+    report = tmp_path / "multi.txt"
+    report.write_text(
+        "\n".join(
+            [
+                "File: sample",
+                "Folders:",
+                f"  - {keep}",
+                f"  - {drop}",
+                f"  - {trap}",
+                "",
+            ]
+        )
+    )
+
+    to_delete = parse_files_to_delete(str(report), str(drop))
+    assert set(to_delete) == {
+        str(drop / "sample.mzML.ipc"),
+        str(drop / "sample.ipc"),
+    }

--- a/tests/scripts/preprocessing/test_delete_same_folder_duplicates.py
+++ b/tests/scripts/preprocessing/test_delete_same_folder_duplicates.py
@@ -1,0 +1,22 @@
+"""Tests for delete_same_folder_duplicates."""
+
+from collections import defaultdict
+
+from scripts.preprocessing.delete_same_folder_duplicates import find_duplicates_to_delete
+
+
+def test_deletes_all_but_first_same_folder_copy() -> None:
+    """Three same-folder copies keep the sorted first and delete the rest."""
+    file_map = defaultdict(list)
+    folder = "/data/acfm/PXD000001"
+    file_map["sample"] = [
+        (folder, f"{folder}/sample.c.ipc"),
+        (folder, f"{folder}/sample.a.ipc"),
+        (folder, f"{folder}/sample.b.ipc"),
+    ]
+
+    to_delete = find_duplicates_to_delete(file_map)
+    assert to_delete == [
+        f"{folder}/sample.b.ipc",
+        f"{folder}/sample.c.ipc",
+    ]

--- a/tests/scripts/preprocessing/test_delete_same_folder_duplicates.py
+++ b/tests/scripts/preprocessing/test_delete_same_folder_duplicates.py
@@ -1,8 +1,12 @@
 """Tests for delete_same_folder_duplicates."""
 
 from collections import defaultdict
+from pathlib import Path
 
-from scripts.preprocessing.delete_same_folder_duplicates import find_duplicates_to_delete
+from scripts.preprocessing.delete_same_folder_duplicates import (
+    find_duplicates_to_delete,
+    parse_input_file,
+)
 
 
 def test_deletes_all_but_first_same_folder_copy() -> None:
@@ -20,3 +24,21 @@ def test_deletes_all_but_first_same_folder_copy() -> None:
         f"{folder}/sample.b.ipc",
         f"{folder}/sample.c.ipc",
     ]
+
+
+def test_parse_does_not_treat_dotted_names_as_one_experiment(tmp_path: Path) -> None:
+    report = tmp_path / "duplicates.txt"
+    folder = "/data/acfm/PXD000001"
+    report.write_text(
+        "\n".join(
+            [
+                f"{folder}/run.v1.ipc",
+                f"{folder}/run.v2.ipc",
+                "",
+            ]
+        )
+    )
+
+    file_map = parse_input_file(str(report))
+    assert set(file_map) == {"run.v1", "run.v2"}
+    assert find_duplicates_to_delete(file_map) == []

--- a/tests/scripts/preprocessing/test_detect_all_duplicates.py
+++ b/tests/scripts/preprocessing/test_detect_all_duplicates.py
@@ -63,3 +63,22 @@ def test_extensions_filters_to_parquet_only(tmp_path: Path) -> None:
     by_default = group_files_by_base_name(str(root))
     assert "sample" in by_default
     assert all(p.endswith(".ipc") for paths in by_default.values() for p in paths)
+
+
+def test_dotted_experiment_names_are_not_collapsed(tmp_path: Path) -> None:
+    """run.v1.ipc and run.v2.ipc are distinct experiments; ipc/mzML.ipc still pair."""
+    root = tmp_path / "data"
+    root.mkdir()
+    (root / "run.v1.ipc").write_text("a")
+    (root / "run.v2.ipc").write_text("b")
+    (root / "sample.ipc").write_text("c")
+    (root / "sample.mzML.ipc").write_text("d")
+
+    grouped = group_files_by_base_name(str(root))
+    assert set(grouped) == {"run.v1", "run.v2", "sample"}
+    assert grouped["run.v1"] == [str(root / "run.v1.ipc")]
+    assert grouped["run.v2"] == [str(root / "run.v2.ipc")]
+    assert set(grouped["sample"]) == {
+        str(root / "sample.ipc"),
+        str(root / "sample.mzML.ipc"),
+    }

--- a/tests/scripts/preprocessing/test_detect_all_duplicates.py
+++ b/tests/scripts/preprocessing/test_detect_all_duplicates.py
@@ -1,8 +1,13 @@
 """Tests for detect_all_duplicates."""
 
+from pathlib import Path
+
 from typer.testing import CliRunner
 
-from scripts.preprocessing.detect_all_duplicates import app as detect_app
+from scripts.preprocessing.detect_all_duplicates import (
+    app as detect_app,
+    group_files_by_base_name,
+)
 
 
 def test_detect_all_duplicates(preprocessing_env) -> None:
@@ -40,3 +45,21 @@ def test_error_handling(preprocessing_env) -> None:
         ],
     )
     assert result.exit_code != 0
+
+
+def test_extensions_filters_to_parquet_only(tmp_path: Path) -> None:
+    """--extensions must control which suffixes are grouped."""
+    root = tmp_path / "data"
+    root.mkdir()
+    (root / "sample.ipc").write_text("a")
+    (root / "sample.parquet").write_text("b")
+    (root / "other.parquet").write_text("c")
+    (root / "other2.parquet").write_text("d")
+
+    by_parquet = group_files_by_base_name(str(root), extensions=[".parquet"])
+    assert set(by_parquet) == {"sample", "other", "other2"}
+    assert all(p.endswith(".parquet") for paths in by_parquet.values() for p in paths)
+
+    by_default = group_files_by_base_name(str(root))
+    assert "sample" in by_default
+    assert all(p.endswith(".ipc") for paths in by_default.values() for p in paths)

--- a/tests/scripts/preprocessing/test_detect_multi_folder_duplicates.py
+++ b/tests/scripts/preprocessing/test_detect_multi_folder_duplicates.py
@@ -1,0 +1,51 @@
+"""Tests for detect_multi_folder_duplicates."""
+
+from pathlib import Path
+
+from scripts.preprocessing.detect_multi_folder_duplicates import (
+    classify_multi_folder_duplicates,
+    find_duplicate_files,
+    parse_duplicate_report,
+)
+
+
+def test_same_folder_ipc_mzml_pair_is_not_multi_folder(tmp_path: Path) -> None:
+    """Same-folder .ipc and .mzML.ipc must not be reported as multi-folder."""
+    report = tmp_path / "duplicates.txt"
+    report.write_text(
+        "\n".join(
+            [
+                "/data/acfm/PXD000001/sample.ipc",
+                "/data/acfm/PXD000001/sample.mzML.ipc",
+                "",
+            ]
+        )
+    )
+
+    file_map = parse_duplicate_report(report)
+    assert file_map == {"sample": ["/data/acfm/PXD000001"]}
+    assert classify_multi_folder_duplicates(file_map) == {}
+
+    output = tmp_path / "multi.txt"
+    result = find_duplicate_files(str(report), str(output))
+    assert result == {}
+    assert not output.exists()
+
+
+def test_distinct_folders_are_multi_folder(tmp_path: Path) -> None:
+    """Copies under different folders remain multi-folder candidates."""
+    report = tmp_path / "duplicates.txt"
+    report.write_text(
+        "\n".join(
+            [
+                "/data/acfm/PXD000001/sample.mzML.ipc",
+                "/data/acfm/PXD000002/sample.mzML.ipc",
+                "",
+            ]
+        )
+    )
+
+    result = find_duplicate_files(str(report), str(tmp_path / "multi.txt"))
+    assert result == {
+        "sample": ["/data/acfm/PXD000001", "/data/acfm/PXD000002"],
+    }

--- a/tests/scripts/preprocessing/test_detect_multi_folder_duplicates.py
+++ b/tests/scripts/preprocessing/test_detect_multi_folder_duplicates.py
@@ -49,3 +49,24 @@ def test_distinct_folders_are_multi_folder(tmp_path: Path) -> None:
     assert result == {
         "sample": ["/data/acfm/PXD000001", "/data/acfm/PXD000002"],
     }
+
+
+def test_dotted_experiment_names_are_not_collapsed(tmp_path: Path) -> None:
+    """run.v1 and run.v2 in the same folder are not one multi-folder group."""
+    report = tmp_path / "duplicates.txt"
+    report.write_text(
+        "\n".join(
+            [
+                "/data/acfm/PXD000001/run.v1.ipc",
+                "/data/acfm/PXD000001/run.v2.ipc",
+                "",
+            ]
+        )
+    )
+
+    file_map = parse_duplicate_report(report)
+    assert file_map == {
+        "run.v1": ["/data/acfm/PXD000001"],
+        "run.v2": ["/data/acfm/PXD000001"],
+    }
+    assert classify_multi_folder_duplicates(file_map) == {}

--- a/tests/scripts/preprocessing/test_parquet_io.py
+++ b/tests/scripts/preprocessing/test_parquet_io.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import polars as pl
+import pytest
+
 from scripts.preprocessing.parquet_io import (
+    atomic_write_parquet,
+    get_storage_options,
     search_data_lookup_key,
     strip_known_data_suffix,
 )
@@ -38,3 +45,68 @@ def test_strip_known_data_suffix_keeps_dotted_experiment_names() -> None:
 def test_strip_known_data_suffix_groups_ipc_with_mzml_ipc() -> None:
     assert strip_known_data_suffix("sample.ipc") == "sample"
     assert strip_known_data_suffix("sample.mzML.ipc") == "sample"
+
+
+def test_get_storage_options_reads_named_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    aws_dir = tmp_path / ".aws"
+    aws_dir.mkdir()
+    (aws_dir / "credentials").write_text(
+        "[pipeline]\naws_access_key_id = AKIATEST\naws_secret_access_key = secret\n"
+    )
+    (aws_dir / "config").write_text("[profile pipeline]\nregion = eu-west-1\n")
+    monkeypatch.setattr(
+        "scripts.preprocessing.parquet_io._find_aws_dir", lambda: str(aws_dir)
+    )
+
+    assert get_storage_options("pipeline") == {
+        "aws_access_key_id": "AKIATEST",
+        "aws_secret_access_key": "secret",
+        "aws_region": "eu-west-1",
+    }
+    assert get_storage_options(None) is None
+    assert get_storage_options("missing") is None
+
+
+def test_atomic_write_parquet_s3_requires_storage_options() -> None:
+    with pytest.raises(ValueError, match="storage_options"):
+        atomic_write_parquet(pl.DataFrame({"a": [1]}), "s3://bucket/key.parquet")
+
+
+def test_atomic_write_parquet_s3_passes_storage_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    written: list[tuple[object, object]] = []
+
+    def fake_write(
+        self: pl.DataFrame, path: object, **kwargs: object
+    ) -> None:
+        written.append((path, kwargs.get("storage_options")))
+
+    monkeypatch.setattr(pl.DataFrame, "write_parquet", fake_write)
+    opts = {
+        "aws_access_key_id": "AKIATEST",
+        "aws_secret_access_key": "secret",
+        "aws_region": "eu-west-1",
+    }
+    atomic_write_parquet(pl.DataFrame({"a": [1]}), "s3://bucket/key.parquet", opts)
+    assert written == [("s3://bucket/key.parquet", opts)]
+
+
+def test_atomic_write_parquet_s3_failure_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    def fake_write(self: pl.DataFrame, path: object, **_kwargs: object) -> None:
+        raise RuntimeError("cloud write unavailable")
+
+    monkeypatch.setattr(pl.DataFrame, "write_parquet", fake_write)
+    with pytest.raises(OSError, match="s3://bucket/key.parquet"):
+        atomic_write_parquet(
+            pl.DataFrame({"a": [1]}),
+            "s3://bucket/key.parquet",
+            {"aws_access_key_id": "id", "aws_secret_access_key": "secret"},
+        )
+    assert not list(tmp_path.rglob("*"))

--- a/tests/scripts/preprocessing/test_parquet_io.py
+++ b/tests/scripts/preprocessing/test_parquet_io.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from scripts.preprocessing.parquet_io import search_data_lookup_key
+from scripts.preprocessing.parquet_io import (
+    search_data_lookup_key,
+    strip_known_data_suffix,
+)
 
 
 def test_lookup_key_excel_mzml_gz() -> None:
@@ -24,3 +27,14 @@ def test_lookup_key_matches_excel_and_parquet() -> None:
     excel = "runA.mzML.gz"
     parquet = "PXD000001/runA_0001-0004.parquet"
     assert search_data_lookup_key(excel) == search_data_lookup_key(parquet)
+
+
+def test_strip_known_data_suffix_keeps_dotted_experiment_names() -> None:
+    assert strip_known_data_suffix("run.v1.ipc") == "run.v1"
+    assert strip_known_data_suffix("run.v2.ipc") == "run.v2"
+    assert strip_known_data_suffix("/data/acfm/PXD000001/run.v1.parquet") == "run.v1"
+
+
+def test_strip_known_data_suffix_groups_ipc_with_mzml_ipc() -> None:
+    assert strip_known_data_suffix("sample.ipc") == "sample"
+    assert strip_known_data_suffix("sample.mzML.ipc") == "sample"

--- a/tests/scripts/splitting/test_create_subsets.py
+++ b/tests/scripts/splitting/test_create_subsets.py
@@ -1,0 +1,19 @@
+"""Tests for create_subsets empty hold-back handling."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from scripts.splitting.create_subsets import _filter_out_glyco_sequences
+
+
+def test_hold_back_all_modified_rows_yields_empty_frame() -> None:
+    """All-[IN:…] files become empty after the hold-back filter."""
+    df = pl.DataFrame(
+        {
+            "sequence": ["PEPTIDE[IN:1]", "A[IN:2]BC"],
+            "hyperscore": [1.0, 2.0],
+        }
+    )
+    filtered = _filter_out_glyco_sequences(df, enabled=True)
+    assert filtered.height == 0

--- a/tests/scripts/verification/test_verify_precursor_charges_and_acq_type.py
+++ b/tests/scripts/verification/test_verify_precursor_charges_and_acq_type.py
@@ -1,8 +1,17 @@
 """Tests for verify_precursor_charges_and_acq_type."""
 
 from pathlib import Path
+
 import polars as pl
 import pytest
+
+from scripts.verification.verify_precursor_charges_and_acq_type import (
+    FILE_PRECURSOR_CHARGE_ERROR_SCHEMA,
+    FilePrecursorChargeErrors,
+    check_if_all_files_in_project_have_errors,
+    errors_to_dataframe,
+)
+
 
 def test_run_verification_creates_output_dir_for_dda_only_reports(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -10,15 +19,7 @@ def test_run_verification_creates_output_dir_for_dda_only_reports(
     """DDA-only verification findings should still create the report directory."""
     from scripts.verification import verify_precursor_charges_and_acq_type as verifier
 
-    incorrect_dia_files = pl.DataFrame(
-        schema={
-            "filename": pl.String,
-            "project": pl.String,
-            "error_type": pl.String,
-            "num_error_rows": pl.Int64,
-            "total_rows": pl.Int64,
-        }
-    )
+    incorrect_dia_files = pl.DataFrame(schema=FILE_PRECURSOR_CHARGE_ERROR_SCHEMA)
     incorrect_dda_files = pl.DataFrame(
         {
             "filename": ["sample.parquet"],
@@ -62,3 +63,83 @@ def test_run_verification_creates_output_dir_for_dda_only_reports(
     assert (output_dir / "incorrect_dda_files.csv").exists()
     assert (output_dir / "project_summary.csv").exists()
     assert len(pl.read_csv(output_dir / "incorrect_dda_files.csv")) == 1
+
+
+def test_errors_to_dataframe_empty_has_schema() -> None:
+    """Empty error lists must keep columns for later concat."""
+    df = errors_to_dataframe([])
+    assert df.height == 0
+    assert df.schema == FILE_PRECURSOR_CHARGE_ERROR_SCHEMA
+
+
+def test_check_project_errors_with_dda_only() -> None:
+    """DDA-only errors must concat with an empty DIA frame."""
+    incorrect_dia = errors_to_dataframe([])
+    incorrect_dda = errors_to_dataframe(
+        [
+            FilePrecursorChargeErrors(
+                "sample", "PXD000001", "zero_precursor_charge", 1, 10
+            )
+        ]
+    )
+    search_data = pl.DataFrame(
+        {
+            "project": ["PXD000001"],
+            "filename": ["sample"],
+            "acquisition": ["DDA"],
+        }
+    )
+
+    summary = check_if_all_files_in_project_have_errors(
+        ["PXD000001/sample.parquet"],
+        incorrect_dia,
+        incorrect_dda,
+        search_data,
+    )
+    assert summary.height == 1
+    assert summary["acquisition"][0] == "DDA"
+
+
+def test_check_project_errors_with_dia_only() -> None:
+    """DIA-only errors must concat with an empty DDA frame."""
+    incorrect_dia = errors_to_dataframe(
+        [
+            FilePrecursorChargeErrors(
+                "sample", "PXD000001", "non_zero_precursor_charge", 2, 10
+            )
+        ]
+    )
+    incorrect_dda = errors_to_dataframe([])
+    search_data = pl.DataFrame(
+        {
+            "project": ["PXD000001"],
+            "filename": ["sample"],
+            "acquisition": ["DIA"],
+        }
+    )
+
+    summary = check_if_all_files_in_project_have_errors(
+        ["PXD000001/sample.parquet"],
+        incorrect_dia,
+        incorrect_dda,
+        search_data,
+    )
+    assert summary.height == 1
+    assert summary["acquisition"][0] == "DIA"
+
+
+def test_check_project_errors_with_no_errors() -> None:
+    """Both empty sides must concat and yield an empty project summary."""
+    summary = check_if_all_files_in_project_have_errors(
+        ["PXD000001/sample.parquet"],
+        errors_to_dataframe([]),
+        errors_to_dataframe([]),
+        pl.DataFrame(
+            {
+                "project": ["PXD000001"],
+                "filename": ["sample"],
+                "acquisition": ["DDA"],
+            }
+        ),
+    )
+    assert summary.height == 0


### PR DESCRIPTION
## Summary
Small fixes and refactors that came up during the data preprocessing port review:

- **ACFM shard naming / empty IPC**
  - Conversion used two shard-count formulas, so exact multiples of `--max-shard-size` were named as if an extra shard existed and `check_conversion` flagged them incomplete
  - Naming and writes now share one `ceil` count
  - Empty IPC no longer writes a placeholder parquet; it raises so the batch error log records the path
- **Duplicate cleanup**
  - Same-folder `.ipc` / `.mzML.ipc` pairs were treated as multi-folder because folders were not uniqued
  - Same-folder delete only removed the second copy when three or more existed
  - Multi-folder delete used substring folder matching and always appended `.mzML.ipc`
  - Detection now unique-folders; same-folder delete keeps the sorted first path; multi-folder delete matches the target folder exactly and resolves existing `.ipc` / `.mzML.ipc` suffixes
  - Identity was truncated at the first `.`, so `run.v1.ipc` and `run.v2.ipc `were one group and same-folder delete could remove an unrelated file; grouping now strips only `.mzML.ipc` / `.ipc` / `.parquet`
- **CLI vs docs**
  - `--column-mapping` JSON replaced the whole default map and omitted `peptide` → `unmodified_peptide`
  - `--extensions` was accepted but ignored
  - `delete_files --dry-run` previewed list lines as-is while a real run stemmed and deleted both `.ipc` and `.parquet`
  - Mapping now merges onto shared defaults; extensions are applied; dry-run previews the same expanded paths; unused `--min-size` stub removed from `find_empty_files`
- **Verification / subsets / writes**
  - Empty DIA or DDA error lists became schemaless frames and broke `pl.concat` when only one side had issues
  - DDA search-data log incorrectly said “DIA”
  - `--hold-back-modified-rows` could leave zero rows and divide by zero in debug logs
  - Files that already had `acquisition` were skipped even when the value disagreed with search data
  - In-place parquet updates now go through shared `atomic_write_parquet` instead of duplicated helpers / direct writes
  - `atomic_write_parquet` turned s3:// URIs into local paths, so acquisition updates could report success without touching the object; S3 writes now use Polars `storage_options` from `--aws-profile` (same keys/region as charge verification), raise `ValueError` if the profile cannot be built, and raise on a failed remote write