### PR TITLE
test: add basic test coverage for data preprocessing scripts

### DIFF
--- a/tests/scripts/preprocessing/test_check_conversion.py
+++ b/tests/scripts/preprocessing/test_check_conversion.py
@@ -1,0 +1,38 @@
+"""Tests for check_conversion helpers."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from scripts.preprocessing.check_conversion import (
+    find_missing_parquet_files,
+    is_shard_incomplete,
+)
+
+_SHARD_PATTERN = re.compile(r".+_\d{4}-\d{4}.parquet$")
+
+
+def test_is_shard_incomplete_detects_gap() -> None:
+    """Incomplete when shard count does not match the declared total."""
+    incomplete = [
+        "sample_0001-0003.parquet",
+        "sample_0003-0003.parquet",
+    ]
+    complete = [
+        "sample_0001-0003.parquet",
+        "sample_0002-0003.parquet",
+        "sample_0003-0003.parquet",
+    ]
+    assert is_shard_incomplete(incomplete, _SHARD_PATTERN) is True
+    assert is_shard_incomplete(complete, _SHARD_PATTERN) is False
+
+
+def test_find_missing_parquet_files_no_parquet(tmp_path: Path) -> None:
+    """IPC with no sibling parquet is reported as missing."""
+    ipc = tmp_path / "sample.ipc"
+    ipc.write_bytes(b"")
+
+    missing = find_missing_parquet_files([str(ipc)])
+
+    assert missing == [(str(ipc), "No matching Parquet files found")]

--- a/tests/scripts/preprocessing/test_enforce_nulls.py
+++ b/tests/scripts/preprocessing/test_enforce_nulls.py
@@ -1,0 +1,41 @@
+"""Tests for enforce_nulls helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+from scripts.preprocessing.enforce_nulls import enforce_nulls
+
+
+def test_enforce_nulls_replaces_unknown_in_collision_energy(tmp_path: Path) -> None:
+    """Placeholder Unknown in collision_energy becomes null."""
+    path = tmp_path / "unknown.parquet"
+    pl.DataFrame(
+        {
+            "collision_energy": ["Unknown", "30.0"],
+            "frag_type": ["HCD", "HCD"],
+        }
+    ).write_parquet(path)
+
+    affected = enforce_nulls(str(tmp_path))
+
+    assert affected == [str(path)]
+    assert pl.read_parquet(path)["collision_energy"].to_list() == [None, "30.0"]
+
+
+def test_enforce_nulls_skips_clean_file(tmp_path: Path) -> None:
+    """Files without Unknown placeholders are left alone."""
+    path = tmp_path / "clean.parquet"
+    pl.DataFrame(
+        {
+            "collision_energy": ["30.0", "35.0"],
+            "frag_type": ["HCD", "HCD"],
+        }
+    ).write_parquet(path)
+
+    affected = enforce_nulls(str(tmp_path))
+
+    assert affected == []
+    assert pl.read_parquet(path)["collision_energy"].to_list() == ["30.0", "35.0"]

--- a/tests/scripts/preprocessing/test_find_modifications.py
+++ b/tests/scripts/preprocessing/test_find_modifications.py
@@ -1,0 +1,88 @@
+"""Tests for find_modifications helpers."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import polars as pl
+
+from scripts.preprocessing.find_modifications import extract_modifications
+
+# Same pattern used by find_modifications().
+_MOD_PATTERN = re.compile(
+    r"(?:"
+    r"[A-Z](?:\[[0-9]+\])+|"
+    r"[a-z](?:\[[0-9]+\])+[A-Z]|"
+    r"[A-Z](?:\[[0-9]+\])*c(?:\[[0-9]+\])+"
+    r")"
+)
+
+
+def test_extract_modifications_finds_bracket_tokens(tmp_path: Path) -> None:
+    """Residue-bracket forms are extracted from modified_peptide."""
+    path = tmp_path / "proj" / "sample.parquet"
+    path.parent.mkdir()
+    pl.DataFrame(
+        {
+            "modified_peptide": ["PEPTIDE[142]K"],
+            "scan": ["scan_001"],
+            "header": ["MS2 scan 1234.5@30.0"],
+        }
+    ).write_parquet(path)
+
+    result = extract_modifications(str(path), _MOD_PATTERN)
+
+    assert result is not None
+    assert result["modification"].to_list() == ["E[142]"]
+
+
+def test_extract_modifications_finds_n_terminal_tokens(tmp_path: Path) -> None:
+    """N-terminal lowercase+bracket forms are extracted from modified_peptide."""
+    path = tmp_path / "proj" / "sample.parquet"
+    path.parent.mkdir()
+    pl.DataFrame(
+        {
+            "modified_peptide": ["n[43]VPEPTIDE"],
+            "scan": ["scan_001"],
+            "header": ["MS2 scan 1234.5@30.0"],
+        }
+    ).write_parquet(path)
+
+    result = extract_modifications(str(path), _MOD_PATTERN)
+
+    assert result is not None
+    assert result["modification"].to_list() == ["n[43]V"]
+
+
+def test_extract_modifications_finds_double_mods(tmp_path: Path) -> None:
+    """Stacked brackets on one residue are kept as a single modification token."""
+    path = tmp_path / "proj" / "sample.parquet"
+    path.parent.mkdir()
+    pl.DataFrame(
+        {
+            "modified_peptide": ["PEPTIDEK[123][456]"],
+            "scan": ["scan_001"],
+            "header": ["MS2 scan 1234.5@30.0"],
+        }
+    ).write_parquet(path)
+
+    result = extract_modifications(str(path), _MOD_PATTERN)
+
+    assert result is not None
+    assert result["modification"].to_list() == ["K[123][456]"]
+
+
+def test_extract_modifications_returns_none_when_no_brackets(tmp_path: Path) -> None:
+    """Unmodified peptides yield no inventory rows."""
+    path = tmp_path / "proj" / "sample.parquet"
+    path.parent.mkdir()
+    pl.DataFrame(
+        {
+            "modified_peptide": ["PEPTIDEK"],
+            "scan": ["scan_001"],
+            "header": ["MS2 scan 1234.5@30.0"],
+        }
+    ).write_parquet(path)
+
+    assert extract_modifications(str(path), _MOD_PATTERN) is None

--- a/tests/scripts/preprocessing/test_infer_isolation_target.py
+++ b/tests/scripts/preprocessing/test_infer_isolation_target.py
@@ -1,0 +1,40 @@
+"""Tests for infer_isolation_target helpers."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from scripts.preprocessing.infer_isolation_target import (
+    infer_it_from_header,
+    infer_it_from_precursor_mz,
+)
+
+
+def test_infer_it_from_header_parses_at_suffix() -> None:
+    """Missing isolation targets are filled from header mz@ce text."""
+    ldf = pl.LazyFrame(
+        {
+            "header": ["MS2 scan 1234.5@30.0"],
+            "isolation_target": [None],
+            "precursor_mz": [999.0],
+        }
+    )
+
+    result = infer_it_from_header(ldf).collect()
+
+    assert result["isolation_target"].to_list() == [1234.5]
+
+
+def test_infer_it_from_precursor_mz_when_header_fails() -> None:
+    """Precursor m/z fills missing isolation targets as a fallback."""
+    ldf = pl.LazyFrame(
+        {
+            "header": ["MS2 scan without at"],
+            "isolation_target": [None],
+            "precursor_mz": [5678.9],
+        }
+    )
+
+    result = infer_it_from_precursor_mz(ldf).collect()
+
+    assert result["isolation_target"].to_list() == [5678.9]

--- a/tests/scripts/verification/test_add_usi_column.py
+++ b/tests/scripts/verification/test_add_usi_column.py
@@ -1,0 +1,25 @@
+"""Tests for add_usi_column helpers."""
+
+from __future__ import annotations
+
+from scripts.verification.add_usi_column import (
+    extract_pxd_or_msv_accession,
+    normalize_scan_identifier,
+)
+
+
+def test_extract_pxd_or_msv_accession_from_path() -> None:
+    """PXD accessions are pulled from filepath segments."""
+    assert (
+        extract_pxd_or_msv_accession("/data/PXD009449/sample.parquet") == "PXD009449"
+    )
+
+
+def test_normalize_scan_identifier_thermo_style() -> None:
+    """Thermo controller/scan text yields the numeric scan id."""
+    assert (
+        normalize_scan_identifier(
+            "controllerType=0 controllerNumber=1 scan=1321"
+        )
+        == "1321"
+    )

--- a/tests/scripts/verification/test_apply_carbamido_from_calc_mz_report.py
+++ b/tests/scripts/verification/test_apply_carbamido_from_calc_mz_report.py
@@ -1,0 +1,23 @@
+"""Tests for apply_carbamido_from_calc_mz_report helpers."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from scripts.verification.apply_carbamido_from_calc_mz_report import (
+    select_projects_for_carb,
+)
+
+
+def test_select_projects_for_carb_picks_eligible_only() -> None:
+    """Only projects with as-is < 100% and after-carb unmodified-C == 100% qualify."""
+    report = pl.DataFrame(
+        {
+            "project": ["PXD_ELIGIBLE", "PXD_ALREADY_OK", "PXD_CARB_FAILS"],
+            "calc_mz_match_rate_as_is_pct": [80.0, 100.0, 50.0],
+            "calc_mz_match_rate_after_carb_unmod_c_rows_pct": [100.0, 100.0, 90.0],
+            "calc_mz_matches_after_carb_unmod_c_rows": [10, 5, 3],
+        }
+    )
+
+    assert select_projects_for_carb(report) == ["PXD_ELIGIBLE"]

--- a/tests/scripts/verification/test_apply_tmt_itraq_from_search_data.py
+++ b/tests/scripts/verification/test_apply_tmt_itraq_from_search_data.py
@@ -1,0 +1,20 @@
+"""Tests for apply_tmt_itraq_from_search_data helpers."""
+
+from __future__ import annotations
+
+from scripts.verification.apply_tmt_itraq_from_search_data import (
+    TagKind,
+    modifications_match_itraq_4plex,
+    parse_spec,
+)
+
+
+def test_modifications_match_itraq_4plex_requires_literal_4() -> None:
+    """Only iTRAQ 4-plex text matches; 8-plex does not."""
+    assert modifications_match_itraq_4plex("iTRAQ 4-plex") is True
+    assert modifications_match_itraq_4plex("iTRAQ 8-plex") is False
+
+
+def test_parse_spec_project_and_kind() -> None:
+    """PROJECT:TAG_KIND specs parse into project id and TagKind."""
+    assert parse_spec("PXD123:TMT_6_8_10") == ("PXD123", TagKind.TMT_6_8_10)

--- a/tests/scripts/verification/test_fix_precursor_charges_from_reports.py
+++ b/tests/scripts/verification/test_fix_precursor_charges_from_reports.py
@@ -1,0 +1,36 @@
+"""Tests for fix_precursor_charges_from_reports helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+from scripts.verification.fix_precursor_charges_from_reports import (
+    _filter_zero_charge_rows,
+    load_csv_if_exists,
+)
+
+
+def test_load_csv_if_exists_missing_returns_empty_schema(tmp_path: Path) -> None:
+    """A missing report path yields an empty frame with the expected schema."""
+    result = load_csv_if_exists(tmp_path / "missing.csv")
+
+    assert result.height == 0
+    assert result.columns == [
+        "filename",
+        "project",
+        "error_type",
+        "num_error_rows",
+        "total_rows",
+    ]
+
+
+def test_filter_zero_charge_rows_removes_zeros() -> None:
+    """DDA rows with precursor charge 0 are dropped."""
+    df = pl.DataFrame({"precursor_charge": [0, 2, 3], "scan": ["a", "b", "c"]})
+
+    filtered = _filter_zero_charge_rows(df, Path("sample.parquet"))
+
+    assert filtered["precursor_charge"].to_list() == [2, 3]
+    assert filtered["scan"].to_list() == ["b", "c"]

--- a/tests/scripts/verification/test_verify_calc_mz.py
+++ b/tests/scripts/verification/test_verify_calc_mz.py
@@ -1,0 +1,38 @@
+"""Tests for verify_calc_mz helpers."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from scripts.verification.verify_calc_mz import (
+    assert_no_tmt_quant_and_itraq_modifications_conflict,
+    calculate_ppm_error,
+    carbamidomethylate_cysteines,
+)
+
+
+def test_carbamidomethylate_cysteines_only_unmodified() -> None:
+    """Bare cysteines gain UNIMOD:4; already labelled cysteines stay put."""
+    assert carbamidomethylate_cysteines("ACDE") == "AC[UNIMOD:4]DE"
+    assert carbamidomethylate_cysteines("AC[UNIMOD:4]DE") == "AC[UNIMOD:4]DE"
+
+
+def test_calculate_ppm_error_zero_at_match() -> None:
+    """Identical calc and reference m/z yield zero ppm error."""
+    assert calculate_ppm_error(500.0, 500.0) == 0.0
+
+
+def test_assert_no_tmt_quant_and_itraq_conflict_raises() -> None:
+    """Non-DIA rows with TMT quant and iTRAQ modifications are fatal."""
+    df = pl.DataFrame(
+        {
+            "project": ["PXD000001"],
+            "file path": ["/data/PXD000001/sample.mzML"],
+            "acquisition": ["DDA"],
+            "quant": ["TMT"],
+            "modifications": ["iTRAQ 4-plex"],
+        }
+    )
+    with pytest.raises(ValueError, match="TMT quant with iTRAQ"):
+        assert_no_tmt_quant_and_itraq_modifications_conflict(df)

--- a/tests/scripts/verification/test_verify_intensity_max_normalisation.py
+++ b/tests/scripts/verification/test_verify_intensity_max_normalisation.py
@@ -1,0 +1,37 @@
+"""Tests for verify_intensity_max_normalisation helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+from scripts.verification.verify_intensity_max_normalisation import (
+    normalise_intensity_row,
+    verify_file,
+)
+
+
+def test_normalise_intensity_row_scales_to_one() -> None:
+    """Peak intensities are scaled so the maximum is 1.0."""
+    intensities, scale = normalise_intensity_row([2.0, 4.0], 1.0)
+
+    assert intensities == [0.5, 1.0]
+    assert scale == 4.0
+
+
+def test_verify_file_flags_non_unit_max(tmp_path: Path) -> None:
+    """Rows whose intensity max is not 1.0 are counted as bad."""
+    path = tmp_path / "sample.parquet"
+    pl.DataFrame(
+        {
+            "intensity_array": [[2.0, 4.0]],
+            "scale_factor": [1.0],
+        }
+    ).write_parquet(path)
+
+    stats = verify_file(path)
+
+    assert stats.rows == 1
+    assert stats.bad_max == 1
+    assert stats.ok == 0


### PR DESCRIPTION
## Summary
- Add a small helper-level unit-test set for remaining preprocessing and verification script methods, freezing basic happy-path contracts.
- **Preprocessing**: conversion shard completeness / missing parquet reporting, `Unknown` → null enforcement, modification extraction (residue, N-terminal, stacked double mods), and isolation-target inference from header or precursor m/z.
- **Verification**: carbamidomethylation / ppm / TMT–iTRAQ conflict checks, intensity max-normalisation, USI accession/scan parsing, TMT/iTRAQ spec predicates, precursor-charge cleanup helpers, and the calc-mz carb project gate.