### PR TITLE
Point at the published embeddings dataset

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -76,7 +76,7 @@ preferred-citation:
   year: 2026
   month: 9
   doi: 10.64898/2026.09.03.747733
-  url: https://www.biorxiv.org/content/10.64898/2026.09.03.747733v1
+  url: https://www.biorxiv.org/content/10.64898/2026.09.03.747733v2
   notes: Preprint
   authors:
     - family-names: Nieuwoudt

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -76,7 +76,7 @@ preferred-citation:
   year: 2026
   month: 9
   doi: 10.64898/2026.09.03.747733
-  url: https://www.biorxiv.org/content/10.64898/2026.09.03.747733v2
+  url: https://doi.org/10.64898/2026.09.03.747733
   notes: Preprint
   authors:
     - family-names: Nieuwoudt

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ If you use InstaNovo-FM in your research, please cite:
   year    = {2026},
   journal = {bioRxiv},
   doi     = {10.64898/2026.09.03.747733},
-  url     = {https://www.biorxiv.org/content/10.64898/2026.09.03.747733v2},
+  url     = {https://doi.org/10.64898/2026.09.03.747733},
   note    = {Preprint}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -215,9 +215,21 @@ the paper:
   [`models.json`](src/instanovo_fm/models.json) and loaded by id with `from_pretrained`,
   which caches under `~/.cache/instanovo-fm/`. See
   [Load a pretrained checkpoint](#load-a-pretrained-checkpoint).
-- **Embeddings:** *Not yet available.* An interactive explorer for the frozen embedding space
-  is hosted at [instadeepai.github.io/InstaNovo-FM](https://instadeepai.github.io/InstaNovo-FM)
-  (goes live with the repository).
+- **Embeddings:** [`InstaDeepAI/InstaNovo-FM-embeddings`](https://huggingface.co/datasets/InstaDeepAI/InstaNovo-FM-embeddings)
+  on HuggingFace, under CC BY-NC-SA 4.0 (the model's terms, since they are derived through it).
+  Two configs of held-out LCFM test spectra, mean-pooled from `instanovo-fm-v0.1.0`: `100k`
+  is the point set published as Figure 3 and carries its exact coordinates, `1M` is a larger
+  draw carrying two 2-D and two 3-D UMAP layouts that appear nowhere in the manuscript. Each
+  row is a 768-d vector plus the metadata identifying its spectrum. The peak arrays are not
+  duplicated — join to the corpus on `usi`, which is **not unique** here, so take first
+  occurrences. An interactive explorer over the same embedding space is hosted at
+  [instadeepai.github.io/InstaNovo-FM](https://instadeepai.github.io/InstaNovo-FM).
+
+  ```python
+  from datasets import load_dataset
+
+  fig3 = load_dataset("InstaDeepAI/InstaNovo-FM-embeddings", "100k", split="train")
+  ```
 
 ## Repository structure
 
@@ -254,7 +266,10 @@ InstaNovo-FM/
 
 An interactive explorer for the frozen embedding space, including a figure viewer and a UMAP
 browser over ~100,000 held-out LCFM spectra, is hosted at
-[instadeepai.github.io/InstaNovo-FM](https://instadeepai.github.io/InstaNovo-FM).
+[instadeepai.github.io/InstaNovo-FM](https://instadeepai.github.io/InstaNovo-FM). The
+embeddings behind it are published as
+[`InstaDeepAI/InstaNovo-FM-embeddings`](https://huggingface.co/datasets/InstaDeepAI/InstaNovo-FM-embeddings),
+so the space can be analysed rather than only browsed.
 
 Design and operational notes live in `docs/`. A hosted docs site is planned. _(TODO: add docs site
 URL.)_ Until then, the guides live in [`docs/`](docs/):
@@ -337,6 +352,7 @@ If you use InstaNovo-FM in your research, please cite:
 | **Model checkpoints** | [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/): attribution, non-commercial, share-alike |
 | **Corpus-production code** ([Figshare](https://doi.org/10.6084/m9.figshare.33368752)) | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) |
 | **Dataset** ([`InstaDeepAI/InstaNovo`](https://huggingface.co/datasets/InstaDeepAI/InstaNovo)) | [EMBL-EBI terms of use](https://www.ebi.ac.uk/about/terms-of-use/), the spectra derive from public PRIDE submissions |
+| **Embeddings** ([`InstaDeepAI/InstaNovo-FM-embeddings`](https://huggingface.co/datasets/InstaDeepAI/InstaNovo-FM-embeddings)) | [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/): derived from those spectra through a non-commercially-licensed model, so the model's terms carry over |
 
 
 The Apache-2.0 grant covers this repository's source alone. It does **not** extend to the

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ the paper:
   Two configs of held-out LCFM test spectra, mean-pooled from `instanovo-fm-v0.1.0`: `100k`
   is the point set published as Figure 3 and carries its exact coordinates, `1M` is a larger
   draw carrying two 2-D and two 3-D UMAP layouts (not yet mentioned in
-  [v1 of the preprint](https://www.biorxiv.org/content/10.64898/2026.09.03.747733v1)). Each
+  [v2 of the preprint](https://www.biorxiv.org/content/10.64898/2026.09.03.747733v2)). Each
   row is a 768-d vector plus the metadata identifying its spectrum. The peak arrays are not
   duplicated — join to the corpus on `usi`, which is **not unique** here, so take first
   occurrences. An interactive explorer over the same embedding space is hosted at
@@ -340,7 +340,7 @@ If you use InstaNovo-FM in your research, please cite:
   year    = {2026},
   journal = {bioRxiv},
   doi     = {10.64898/2026.09.03.747733},
-  url     = {https://www.biorxiv.org/content/10.64898/2026.09.03.747733v1},
+  url     = {https://www.biorxiv.org/content/10.64898/2026.09.03.747733v2},
   note    = {Preprint}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -219,7 +219,8 @@ the paper:
   on HuggingFace, under CC BY-NC-SA 4.0 (the model's terms, since they are derived through it).
   Two configs of held-out LCFM test spectra, mean-pooled from `instanovo-fm-v0.1.0`: `100k`
   is the point set published as Figure 3 and carries its exact coordinates, `1M` is a larger
-  draw carrying two 2-D and two 3-D UMAP layouts that appear nowhere in the manuscript. Each
+  draw carrying two 2-D and two 3-D UMAP layouts (not yet mentioned in
+  [v1 of the preprint](https://www.biorxiv.org/content/10.64898/2026.09.03.747733v1)). Each
   row is a 768-d vector plus the metadata identifying its spectrum. The peak arrays are not
   duplicated — join to the corpus on `usi`, which is **not unique** here, so take first
   occurrences. An interactive explorer over the same embedding space is hosted at

--- a/docs/foundation_model.md
+++ b/docs/foundation_model.md
@@ -136,7 +136,8 @@ recovered from frozen embeddings:
 The frozen embeddings of the held-out LCFM test split are published as
 [`InstaDeepAI/InstaNovo-FM-embeddings`](https://huggingface.co/datasets/InstaDeepAI/InstaNovo-FM-embeddings):
 a `100k` config carrying the Figure 3 point set with its exact published coordinates, and a
-`1M` config carrying two 2-D and two 3-D UMAP layouts that appear nowhere in the manuscript.
+`1M` config carrying two 2-D and two 3-D UMAP layouts (not yet mentioned in
+[v1 of the preprint](https://www.biorxiv.org/content/10.64898/2026.09.03.747733v1)).
 Each row is the 768-d mean-pooled vector plus the metadata identifying its spectrum.
 
 Use them to analyse the embedding space without re-running inference. To reproduce them

--- a/docs/foundation_model.md
+++ b/docs/foundation_model.md
@@ -131,6 +131,18 @@ recovered from frozen embeddings:
 - **Integrated-gradients attribution** — which input peaks the model actually used to reconstruct a
   masked group, and whether those peaks correspond to chemically meaningful relationships.
 
+## The published embeddings
+
+The frozen embeddings of the held-out LCFM test split are published as
+[`InstaDeepAI/InstaNovo-FM-embeddings`](https://huggingface.co/datasets/InstaDeepAI/InstaNovo-FM-embeddings):
+a `100k` config carrying the Figure 3 point set with its exact published coordinates, and a
+`1M` config carrying two 2-D and two 3-D UMAP layouts that appear nowhere in the manuscript.
+Each row is the 768-d mean-pooled vector plus the metadata identifying its spectrum.
+
+Use them to analyse the embedding space without re-running inference. To reproduce them
+instead, `scripts/release/prepare_embeddings.py` turns the eval harness's `embeddings.h5`
+into the published shards.
+
 ## Corpora
 
 - **MCFM** — a curated, high-confidence subset.

--- a/docs/foundation_model.md
+++ b/docs/foundation_model.md
@@ -137,7 +137,7 @@ The frozen embeddings of the held-out LCFM test split are published as
 [`InstaDeepAI/InstaNovo-FM-embeddings`](https://huggingface.co/datasets/InstaDeepAI/InstaNovo-FM-embeddings):
 a `100k` config carrying the Figure 3 point set with its exact published coordinates, and a
 `1M` config carrying two 2-D and two 3-D UMAP layouts (not yet mentioned in
-[v1 of the preprint](https://www.biorxiv.org/content/10.64898/2026.09.03.747733v1)).
+[v2 of the preprint](https://www.biorxiv.org/content/10.64898/2026.09.03.747733v2)).
 Each row is the 768-d mean-pooled vector plus the metadata identifying its spectrum.
 
 Use them to analyse the embedding space without re-running inference. To reproduce them

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,5 +1,17 @@
 # Dataset release scripts
 
+Two artefacts go to two HuggingFace repos, and the scripts are deliberately separate:
+
+| artefact | repo | scripts |
+|---|---|---|
+| the labelled spectra corpus, in tiers and flavours | [`InstaDeepAI/InstaNovo`](https://huggingface.co/datasets/InstaDeepAI/InstaNovo) | `hf_probe.py`, `hf_upload.py`, `dataset_card.md` |
+| the frozen spectrum embeddings | [`InstaDeepAI/InstaNovo-FM-embeddings`](https://huggingface.co/datasets/InstaDeepAI/InstaNovo-FM-embeddings) | `prepare_embeddings.py`, `hf_upload_embeddings.py`, `embeddings_card.md` |
+
+They share no tier logic and carry different licences, so folding the embeddings into
+`hf_upload.py` would have meant a flag that changes what every other flag means. The
+embeddings runbook is in the header of `hf_upload_embeddings.py`; the rest of this file
+is about the corpus.
+
 Upload the labelled confidence tiers to the HuggingFace dataset repo.
 
 ## Order of operations

--- a/scripts/release/dataset_card.md
+++ b/scripts/release/dataset_card.md
@@ -314,7 +314,7 @@ proteomics*. bioRxiv. <https://doi.org/10.64898/2026.09.03.747733>
   year    = {2026},
   journal = {bioRxiv},
   doi     = {10.64898/2026.09.03.747733},
-  url     = {https://www.biorxiv.org/content/10.64898/2026.09.03.747733v2},
+  url     = {https://doi.org/10.64898/2026.09.03.747733},
   note    = {Preprint}
 }
 ```

--- a/scripts/release/dataset_card.md
+++ b/scripts/release/dataset_card.md
@@ -314,7 +314,7 @@ proteomics*. bioRxiv. <https://doi.org/10.64898/2026.09.03.747733>
   year    = {2026},
   journal = {bioRxiv},
   doi     = {10.64898/2026.09.03.747733},
-  url     = {https://www.biorxiv.org/content/10.64898/2026.09.03.747733v1},
+  url     = {https://www.biorxiv.org/content/10.64898/2026.09.03.747733v2},
   note    = {Preprint}
 }
 ```


### PR DESCRIPTION
The embeddings are now published as
[`InstaDeepAI/InstaNovo-FM-embeddings`](https://huggingface.co/datasets/InstaDeepAI/InstaNovo-FM-embeddings)
— two configs of held-out LCFM test spectra, mean-pooled from `instanovo-fm-v0.1.0`,
CC BY-NC-SA 4.0, 3.15 GiB.

| config | spectra | what it is |
|---|---|---|
| `100k` | 100,000 | the point set published as Figure 3, carrying its exact coordinates |
| `1M` | 1,000,000 | a larger draw, with two 2-D and two 3-D UMAP layouts that appear nowhere in the manuscript |

This PR makes the repository say so, in the four places that previously said
otherwise or said nothing.

- **README, "Pretrained weights & data"** — the bullet read *"Embeddings: **Not yet
  available.**"* It now names both configs, says what a row contains, and shows the
  `load_dataset` call.
- **README, "Documentation"** — the explorer paragraph now notes the embeddings are
  published too, so the space can be analysed rather than only browsed.
- **README, "License"** — a row for the embeddings. They are derived from EMBL-EBI
  spectra *through* a non-commercially-licensed model, so the model's CC BY-NC-SA 4.0
  carries over; the table previously covered only the corpus.
- **`docs/foundation_model.md`** — a short section where the embedding space is
  described, pointing at the data and at the script that reproduces it.

`scripts/release/README.md` opened by saying it uploads the corpus, which is now half
true: that directory serves two repos, with different licences and no shared tier logic.
It now says which scripts belong to which.

### The `usi` caveat travels with the reference

`usi` is **not** a unique key in this corpus — 1,000,000 rows carry 999,720 distinct
values, the repeats being timsTOF spectra whose USI keeps only `scan` and drops the frame.
Anyone joining the embeddings to the corpus hits this, and the README is where they will
look first, so it is stated there rather than only on the dataset card.

### Also, in the explorer (separate, already live)

Both the explorer at the site root and the 1M preview now carry an `embeddings ↗` link in
the header, beside the repository back-link, so a reader who wants the vectors rather than
the picture has somewhere to go. That lives on `gh-pages` and is not part of this PR.
