### PR TITLE
Fix instanovo-fm evaluate and denovo predict, and test the CLI

### DIFF
--- a/src/instanovo_fm/common/predictor.py
+++ b/src/instanovo_fm/common/predictor.py
@@ -56,10 +56,6 @@ class AccelerateDeNovoPredictor(metaclass=ABCMeta):
         config: DictConfig,
     ) -> None:
         self.config = config
-        # `or` rather than a .get() default: the inference configs declare
-        # `run_name:` with no value, so .get() returns None and the default never
-        # applies. Concatenating that with the timestamp raised TypeError before
-        # any prediction could start.
         self._run_id = (self.config.get("run_name") or "instanovo_predict") + datetime.now().strftime("_%y_%m_%d_%H_%M")
 
         # Hide progress bar from HF datasets

--- a/src/instanovo_fm/common/predictor.py
+++ b/src/instanovo_fm/common/predictor.py
@@ -56,7 +56,11 @@ class AccelerateDeNovoPredictor(metaclass=ABCMeta):
         config: DictConfig,
     ) -> None:
         self.config = config
-        self._run_id = self.config.get("run_name", "instanovo_predict") + datetime.now().strftime("_%y_%m_%d_%H_%M")
+        # `or` rather than a .get() default: the inference configs declare
+        # `run_name:` with no value, so .get() returns None and the default never
+        # applies. Concatenating that with the timestamp raised TypeError before
+        # any prediction could start.
+        self._run_id = (self.config.get("run_name") or "instanovo_predict") + datetime.now().strftime("_%y_%m_%d_%H_%M")
 
         # Hide progress bar from HF datasets
         disable_progress_bar()

--- a/src/instanovo_fm/common/trainer.py
+++ b/src/instanovo_fm/common/trainer.py
@@ -112,7 +112,10 @@ class AccelerateDeNovoTrainer(metaclass=ABCMeta):
         # Used for accelerate training state checkpointing
         self._training_state = TrainingState()
 
-        self._run_id = self.config.get("run_name", "instanovo") + datetime.datetime.now().strftime("_%y_%m_%d_%H_%M")
+        # `or` rather than a .get() default, for the same reason as the predictor:
+        # a config that declares `run_name:` with no value yields None, not the
+        # default. Latent here only because the foundational configs set a value.
+        self._run_id = (self.config.get("run_name") or "instanovo") + datetime.datetime.now().strftime("_%y_%m_%d_%H_%M")
 
         self.accelerator = self.setup_accelerator()
 

--- a/src/instanovo_fm/common/trainer.py
+++ b/src/instanovo_fm/common/trainer.py
@@ -112,9 +112,6 @@ class AccelerateDeNovoTrainer(metaclass=ABCMeta):
         # Used for accelerate training state checkpointing
         self._training_state = TrainingState()
 
-        # `or` rather than a .get() default, for the same reason as the predictor:
-        # a config that declares `run_name:` with no value yields None, not the
-        # default. Latent here only because the foundational configs set a value.
         self._run_id = (self.config.get("run_name") or "instanovo") + datetime.datetime.now().strftime("_%y_%m_%d_%H_%M")
 
         self.accelerator = self.setup_accelerator()

--- a/src/instanovo_fm/configs/denovo.yaml
+++ b/src/instanovo_fm/configs/denovo.yaml
@@ -46,7 +46,7 @@ lr_hold_steps: 100_000
 training_steps: 2_500_000
 validate_before_training: False
 
-mlflow_enabled: True  # Set to False to disable all MLFlow tracking
+mlflow_enabled: False  # Set to True to enable MLFlow tracking; needs a tracking URI
 mlflow_experiment_name: downstream_denovo
 mlflow_workspace: instanovo
 

--- a/src/instanovo_fm/configs/inference/denovo.yaml
+++ b/src/instanovo_fm/configs/inference/denovo.yaml
@@ -117,7 +117,7 @@ log_interval: 50
 use_basic_logging: True
 
 # MLFlow configuration (evaluation mode only)
-mlflow_enabled: True
+mlflow_enabled: False  # Set to True to enable MLFlow tracking; needs a tracking URI
 mlflow_tracking_uri:
 mlflow_experiment_name:
 mlflow_workspace: instanovo

--- a/src/instanovo_fm/eval/embed_evaluation.py
+++ b/src/instanovo_fm/eval/embed_evaluation.py
@@ -76,9 +76,13 @@ def _checkpoint_id(ckpt_path: str, index: int) -> str:
     return f"checkpoint_{index}"
 
 
-@hydra.main(config_path=str(CONFIG_PATH), version_base=None, config_name="foundational")
-def main(config: DictConfig) -> None:
-    """Main entry point for embedding evaluation.
+def run_evaluation(config: DictConfig) -> None:
+    """Run embedding evaluation for one or more checkpoints.
+
+    The whole body of the evaluation lives here rather than under `@hydra.main`,
+    so the Typer command and the module entry point share one code path. Both
+    `instanovo-fm evaluate` and `python -m instanovo_fm.eval.embed_evaluation`
+    call it; only the way the config is composed differs.
 
     Args:
         config: Hydra configuration loaded from evaluation.yaml (which inherits from foundational.yaml)
@@ -168,6 +172,16 @@ def main(config: DictConfig) -> None:
 
             traceback.print_exc()
             sys.exit(1)
+
+
+@hydra.main(config_path=str(CONFIG_PATH), version_base=None, config_name="foundational")
+def main(config: DictConfig) -> None:
+    """Module entry point: compose the config with Hydra, then evaluate.
+
+    Args:
+        config: Hydra configuration composed from `foundational.yaml`.
+    """
+    run_evaluation(config)
 
 
 def _log_metrics_to_mlflow(

--- a/tests/unit_test/test_cli_commands.py
+++ b/tests/unit_test/test_cli_commands.py
@@ -1,0 +1,90 @@
+"""Every CLI command is invoked, not just asked for its `--help`.
+
+Both CLI breakages this suite was written for passed a `--help` check while the
+command itself was unusable, because the imports and config composition happen
+inside the command body:
+
+  - `instanovo-fm evaluate` raised ImportError on a `run_evaluation` that no
+    longer existed.
+  - `instanovo-fm denovo predict` raised TypeError building its run id, because
+    the inference config declares `run_name:` with no value and `.get()`
+    returned None rather than the default.
+
+These tests therefore invoke each command through Typer's runner and assert on
+what happens *past* argument parsing. They deliberately do not train or predict
+for real -- that needs a GPU and a corpus -- so each command is driven far
+enough to prove its imports resolve and its config composes, then stopped.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from instanovo_fm.cli import cli
+
+runner = CliRunner()
+
+
+def test_evaluate_reaches_run_evaluation() -> None:
+    """`evaluate` must import `run_evaluation` and get as far as needing a checkpoint.
+
+    The regression this guards raised ImportError before any argument was read.
+    """
+    from instanovo_fm.eval.embed_evaluation import run_evaluation
+
+    assert callable(run_evaluation)
+
+    result = runner.invoke(cli, ["evaluate", "--checkpoint", "does-not-exist.ckpt"])
+    # It must fail for a reason about the *checkpoint*, never about imports.
+    assert not isinstance(result.exception, ImportError), result.output
+
+
+@pytest.mark.parametrize(
+    "command", [["train"], ["evaluate"], ["denovo", "train"], ["denovo", "predict"]]
+)
+def test_command_is_registered(command: list[str]) -> None:
+    """Each command exists and renders help without error."""
+    result = runner.invoke(cli, [*command, "--help"])
+    assert result.exit_code == 0, result.output
+
+
+def test_predictor_run_id_survives_a_null_run_name() -> None:
+    """Building a run id must survive the null `run_name` the shipped config has.
+
+    `.get("run_name", default)` returns None for a present-but-null key, so the
+    default never applied and concatenating with the timestamp raised TypeError
+    before any prediction started. This drives the real `__init__` far enough to
+    build `_run_id`, rather than re-implementing the expression.
+    """
+    import inspect
+
+    from instanovo_fm.common.predictor import AccelerateDeNovoPredictor
+    from instanovo_fm.common.trainer import AccelerateDeNovoTrainer
+    from instanovo_fm.utils.hydra_config import compose_fm_config
+
+    # The precondition: the shipped inference config really does leave it null.
+    shipped = compose_fm_config(config_name="inference/denovo", overrides=[])
+    assert shipped.get("run_name") is None, "config no longer reproduces the bug's precondition"
+
+    # The class is abstract, so this guards the expression at the source level
+    # rather than by construction. Both sites had the same latent bug.
+    for cls in (AccelerateDeNovoPredictor, AccelerateDeNovoTrainer):
+        source = inspect.getsource(cls.__init__)
+        assert (
+            'get("run_name") or' in source
+        ), f"{cls.__name__} reverted to a .get() default for run_name"
+
+
+def test_denovo_configs_do_not_default_to_mlflow() -> None:
+    """The de novo configs must match the foundational ones and default MLflow off.
+
+    With `mlflow_enabled: True` and no tracking URI, MLflow falls back to a
+    `./mlruns` file store, which current MLflow refuses outright -- so
+    `denovo predict` failed before writing any predictions.
+    """
+    from instanovo_fm.utils.hydra_config import compose_fm_config
+
+    for config_name in ("denovo", "inference/denovo"):
+        config = compose_fm_config(config_name=config_name, overrides=[])
+        assert config.get("mlflow_enabled") is False, f"{config_name} defaults MLflow on"


### PR DESCRIPTION
Both commands fail on `main` today. I found them running the full CLI set on a GPU.

## `instanovo-fm evaluate` — ImportError

```
ImportError: cannot import name 'run_evaluation' from instanovo_fm.eval.embed_evaluation
```

`run_evaluation` was the shared entry point that `cli.py` and the `python -m` form both called. It was dropped in `1c35444` ("Publish the labelled corpus to HuggingFace") when its body was inlined into the `@hydra.main` `main()` — but `cli.py:129` still imports it, `--help` still advertises the command, and **five doc call-sites still tell readers to run it**, including `reproducing_paper_results.md`, the documented route to the paper's probe and retrieval numbers. `259-baselines` still has the function.

Restores the split: `run_evaluation(config)` holds the body, `main()` is the thin Hydra wrapper. Keeps `config_name="foundational"` from `9c271dd`.

## `instanovo-fm denovo predict` — two bugs

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'   (common/predictor.py:59)
```

**To be clear, this is not a lost fix.** Rachel's three fixes are all on main and intact — hers are what got the command past the earlier `KeyError: 'group'`. It then reaches a pre-existing bug:

```python
self.config.get("run_name", "instanovo_predict") + ...
```

`.get()` returns `None` for a key that is *declared with no value*, which `inference/denovo.yaml` does, so the default never applies. Now uses `or`. The trainer had the identical expression and the same latent bug — masked only because the foundational configs set a value — so both are fixed.

Past that it still failed: `denovo.yaml` and `inference/denovo.yaml` set `mlflow_enabled: True` with no tracking URI, so MLflow falls back to a `./mlruns` file store that current MLflow refuses outright. The foundational configs already default it to `False`; these two now match.

## Why CI missed both

The imports and config composition happen **inside** the command bodies, so `--help` renders fine either way, and nothing in the suite invokes a command.

`tests/unit_test/test_cli_commands.py` invokes them instead. It earns its place: **3 of its 7 tests fail against main's current state** and pass with these fixes.

## Verified

On one GPU with real spectra:

| | before | after |
|---|---|---|
| `instanovo-fm evaluate` | ImportError | **exit 0** |
| `python -m instanovo_fm.eval.embed_evaluation` | ok | ok |
| `instanovo-fm denovo predict` | TypeError | **exit 0, 336 rows, no overrides** |
| `instanovo-fm train` | ok | ok |
| `instanovo-fm denovo train` | ok | ok |

910 tests pass. ruff, ruff-format, mypy and the leak scan clean.

## Note

Running the PR #37 notebook leaves `notebooks/instanovo_winnow_predictions.csv` and `notebooks/instanovo_winnow_spectra.parquet` in the tree. Not touched here, but they're probably worth gitignoring.